### PR TITLE
perf+docs: cut list_incidents token usage — pagination hint + Code Mode as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Use the hosted MCP server. No local installation required.
 
 ### Hosted Transport Options
 
-- **Streamable HTTP (recommended):** `https://mcp.rootly.com/mcp`
+- **Code Mode (recommended):** `https://mcp.rootly.com/mcp-codemode`
+- **Streamable HTTP:** `https://mcp.rootly.com/mcp`
 - **SSE (stable alternative):** `https://mcp.rootly.com/sse`
-- **Code Mode:** `https://mcp.rootly.com/mcp-codemode`
 
-Hosted tool profiles:
+> **Use Code Mode.** Instead of registering ~200 individual tools (whose schemas are re-sent on every model turn), Code Mode exposes a compact set of meta-tools — `list_tools`, `tool_search`, `get_schema`, `tags`, and `execute`. The model discovers the tools it needs and writes a short async Python block in `execute` that chains multiple `await call_tool(...)` calls **server-side**, returning only the final result. In practice this means **dramatically lower token usage** (a handful of tool schemas instead of hundreds) and **fewer round-trips** for multi-step work (one `execute` call instead of N tool calls). Prefer it for any agent that can write code — which is virtually all modern LLM clients. The plain Streamable HTTP and SSE endpoints remain available for clients that need the classic one-tool-per-operation surface.
+
+Hosted tool profiles (apply to the classic Streamable HTTP / SSE endpoints):
 
 - **Full (default):** use the URLs above as-is
 - **Slim (~70 tools):** add `?tool_profile=slim` to the hosted URL, for example `https://mcp.rootly.com/mcp?tool_profile=slim`
@@ -29,48 +31,7 @@ Hosted tool profiles:
 
 ### General Remote Setup
 
-**With OAuth2 (recommended):**
-
-```json
-{
-  "mcpServers": {
-    "rootly": {
-      "url": "https://mcp.rootly.com/mcp"
-    }
-  }
-}
-```
-
-Your MCP client handles OAuth2 login automatically — a browser window opens for you to authenticate with Rootly. No API token needed.
-
-**With API Token:**
-
-```json
-{
-  "mcpServers": {
-    "rootly": {
-      "url": "https://mcp.rootly.com/mcp",
-      "headers": {
-        "Authorization": "Bearer YOUR_ROOTLY_API_TOKEN"
-      }
-    }
-  }
-}
-```
-
-SSE (alternative):
-
-```json
-{
-  "mcpServers": {
-    "rootly": {
-      "url": "https://mcp.rootly.com/sse"
-    }
-  }
-}
-```
-
-Code Mode:
+**Code Mode with OAuth2 (recommended):**
 
 ```json
 {
@@ -82,6 +43,40 @@ Code Mode:
 }
 ```
 
+Your MCP client handles OAuth2 login automatically — a browser window opens for you to authenticate with Rootly. No API token needed. Code Mode supports OAuth2 (and bearer tokens) identically to the classic endpoint.
+
+**Code Mode with API Token:**
+
+```json
+{
+  "mcpServers": {
+    "rootly": {
+      "url": "https://mcp.rootly.com/mcp-codemode",
+      "headers": {
+        "Authorization": "Bearer YOUR_ROOTLY_API_TOKEN"
+      }
+    }
+  }
+}
+```
+
+<details>
+<summary>Classic one-tool-per-operation endpoints (Streamable HTTP / SSE)</summary>
+
+Use these if your client can't write code in Code Mode's `execute` tool. Swap the URL for `https://mcp.rootly.com/mcp` (Streamable HTTP) or `https://mcp.rootly.com/sse` (SSE); both accept OAuth2 or a `Authorization: Bearer` token the same way.
+
+```json
+{
+  "mcpServers": {
+    "rootly": {
+      "url": "https://mcp.rootly.com/mcp"
+    }
+  }
+}
+```
+
+</details>
+
 ### Agent Setup
 
 <details>
@@ -89,19 +84,19 @@ Code Mode:
 
 <br>
 
-**With OAuth2 (recommended):**
+**With OAuth2 (recommended) — Code Mode:**
 
 ```bash
-claude mcp add --transport http rootly https://mcp.rootly.com/mcp
+claude mcp add --transport http rootly https://mcp.rootly.com/mcp-codemode
 
-# Code Mode:
-claude mcp add --transport http rootly-codemode https://mcp.rootly.com/mcp-codemode
+# Classic one-tool-per-operation endpoint, if you need it:
+claude mcp add --transport http rootly-classic https://mcp.rootly.com/mcp
 ```
 
 **With API Token:**
 
 ```bash
-claude mcp add --transport http rootly https://mcp.rootly.com/mcp \
+claude mcp add --transport http rootly https://mcp.rootly.com/mcp-codemode \
   --header "Authorization: Bearer YOUR_ROOTLY_API_TOKEN"
 ```
 
@@ -112,7 +107,7 @@ claude mcp add --transport http rootly https://mcp.rootly.com/mcp \
   "mcpServers": {
     "rootly": {
       "type": "http",
-      "url": "https://mcp.rootly.com/mcp"
+      "url": "https://mcp.rootly.com/mcp-codemode"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Choose one transport per server process:
 
 - **Streamable HTTP** endpoint path: `/mcp`
 - **SSE** endpoint path: `/sse`
-- **Code Mode (experimental)** endpoint path: `/mcp-codemode` in hosted dual-transport mode
+- **Code Mode (recommended)** endpoint path: `/mcp-codemode` in hosted dual-transport mode
 
 Hosted and self-hosted deployments now both expose the full tool surface by default.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Use the hosted MCP server. No local installation required.
 - **SSE (stable alternative):** `https://mcp.rootly.com/sse`
 
 > **Use Code Mode.** Instead of registering ~200 individual tools (whose schemas are re-sent on every model turn), Code Mode exposes a compact set of meta-tools — `list_tools`, `tool_search`, `get_schema`, `tags`, and `execute`. The model discovers the tools it needs and writes a short async Python block in `execute` that chains multiple `await call_tool(...)` calls **server-side**, returning only the final result. In practice this means **dramatically lower token usage** (a handful of tool schemas instead of hundreds) and **fewer round-trips** for multi-step work (one `execute` call instead of N tool calls). Prefer it for any agent that can write code — which is virtually all modern LLM clients. The plain Streamable HTTP and SSE endpoints remain available for clients that need the classic one-tool-per-operation surface.
+>
+> ⚠️ **Connect Code Mode *instead of* the classic endpoints, not alongside them.** If both surfaces are available to the same client, the model tends to call the classic tools directly and skips `execute` entirely — so the ~200 tool schemas still load and you lose the token savings. Pick one endpoint per client.
 
 Hosted tool profiles (apply to the classic Streamable HTTP / SSE endpoints):
 

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -40,6 +40,39 @@ def _split_csv_values(value: str) -> list[str]:
     return [part.strip() for part in value.split(",") if part.strip()]
 
 
+# Below this page size, a multi-page sweep is considered inefficient and we
+# surface a hint steering callers toward collect_incidents / larger pages.
+_EFFICIENT_PAGE_SIZE = 25
+# Only hint once a full sweep would take more than this many paginated calls.
+_PAGINATION_HINT_PAGE_THRESHOLD = 5
+
+
+def _pagination_efficiency_hint(
+    *, page_size: int, has_more: bool, total_pages: int | None, total_count: int | None
+) -> JsonDict | None:
+    """Return a non-breaking steering hint when a caller is paginating list_incidents
+    inefficiently (small page_size against a large result set), or None otherwise.
+
+    This addresses clients that walk the full incident history one small page at a
+    time (e.g. page_size=1), turning a bounded fetch into hundreds of tool calls.
+    The hint is advisory only — it does not change the response data or status.
+    """
+    pages = total_pages or 0
+    if not has_more or page_size >= _EFFICIENT_PAGE_SIZE or pages <= _PAGINATION_HINT_PAGE_THRESHOLD:
+        return None
+
+    return {
+        "instead_of": "list_incidents",
+        "use": "collect_incidents",
+        "reason": (
+            f"page_size={page_size} against {total_count} matching incidents needs "
+            f"~{pages} paginated calls. Use collect_incidents for a bounded bulk fetch "
+            f"in one call, raise page_size (max 100), or add filters "
+            f"(team_ids, service_ids, severity, started_after) to narrow the result set."
+        ),
+    }
+
+
 def _normalize_optional_text(value: str | None) -> str | None:
     """Normalize optional text inputs by trimming whitespace and empty values."""
     if value is None:
@@ -445,7 +478,8 @@ def register_incident_tools(
             incidents = response_data.get("data", [])
             meta = response_data.get("meta", {})
 
-            return {
+            has_more = meta.get("next_page") is not None
+            result: JsonDict = {
                 "incidents": [_summarize_incident_record(incident) for incident in incidents],
                 "returned_incidents": len(incidents),
                 "pagination": {
@@ -456,10 +490,19 @@ def register_incident_tools(
                     "prev_page": meta.get("prev_page"),
                     "total_pages": meta.get("total_pages"),
                     "total_count": meta.get("total_count"),
-                    "has_more": meta.get("next_page") is not None,
+                    "has_more": has_more,
                 },
                 "filters": filters,
             }
+            hint = _pagination_efficiency_hint(
+                page_size=page_size,
+                has_more=has_more,
+                total_pages=meta.get("total_pages"),
+                total_count=meta.get("total_count"),
+            )
+            if hint:
+                result["_use_tool"] = hint
+            return result
         except Exception as e:
             error_type, error_message = mcp_error.categorize_error(e)
             return _augment_pagination_error(

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -58,7 +58,11 @@ def _pagination_efficiency_hint(
     The hint is advisory only — it does not change the response data or status.
     """
     pages = total_pages or 0
-    if not has_more or page_size >= _EFFICIENT_PAGE_SIZE or pages <= _PAGINATION_HINT_PAGE_THRESHOLD:
+    if (
+        not has_more
+        or page_size >= _EFFICIENT_PAGE_SIZE
+        or pages <= _PAGINATION_HINT_PAGE_THRESHOLD
+    ):
         return None
 
     return {

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1023,9 +1023,7 @@ class TestPaginationEfficiencyHint:
 
     def test_no_hint_when_no_more_pages(self):
         assert (
-            _pagination_efficiency_hint(
-                page_size=1, has_more=False, total_pages=1, total_count=1
-            )
+            _pagination_efficiency_hint(page_size=1, has_more=False, total_pages=1, total_count=1)
             is None
         )
 
@@ -1040,9 +1038,7 @@ class TestPaginationEfficiencyHint:
     def test_no_hint_for_short_sweep_under_threshold(self):
         # small page_size but only a few pages to go — not worth nagging
         assert (
-            _pagination_efficiency_hint(
-                page_size=5, has_more=True, total_pages=3, total_count=12
-            )
+            _pagination_efficiency_hint(page_size=5, has_more=True, total_pages=3, total_count=12)
             is None
         )
 

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -21,6 +21,7 @@ from rootly_mcp_server.tools.incidents import (
     INCIDENT_LIST_FIELDS,
     _augment_pagination_error,
     _normalize_incident_reference,
+    _pagination_efficiency_hint,
     _summarize_incident_record,
     register_incident_tools,
 )
@@ -969,6 +970,95 @@ class TestStructuredListIncidentsTool:
         assert result["error"] is True
         assert result["error_type"] == "validation_error"
         assert "Could not resolve team names/slugs" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_list_incidents_adds_hint_on_tiny_page_size_sweep(self):
+        """A page_size=1 walk over a large result set gets a non-breaking
+        steering hint toward collect_incidents (the Odin page_size=1 pattern)."""
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": [{"id": "inc-1", "type": "incidents", "attributes": {"title": "x"}}],
+            "meta": {"current_page": 1, "next_page": 2, "total_pages": 281, "total_count": 281},
+        }
+        request.return_value = response
+
+        result = await tools["list_incidents"](page_size=1)
+
+        assert "_use_tool" in result
+        assert result["_use_tool"]["use"] == "collect_incidents"
+        # data/status are untouched — hint is advisory only.
+        assert result["returned_incidents"] == 1
+        assert result["pagination"]["has_more"] is True
+
+    @pytest.mark.asyncio
+    async def test_list_incidents_no_hint_at_default_page_size(self):
+        """Default page_size paginating a large set is normal — no hint nag."""
+        tools, request = self._register_tools()
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": [{"id": "inc-1", "type": "incidents", "attributes": {"title": "x"}}],
+            "meta": {"current_page": 1, "next_page": 2, "total_pages": 12, "total_count": 281},
+        }
+        request.return_value = response
+
+        result = await tools["list_incidents"](page_size=25)
+
+        assert "_use_tool" not in result
+
+
+@pytest.mark.unit
+class TestPaginationEfficiencyHint:
+    """Direct unit tests for the list_incidents pagination steering hint."""
+
+    def test_hint_fires_for_tiny_page_size_large_set(self):
+        hint = _pagination_efficiency_hint(
+            page_size=1, has_more=True, total_pages=281, total_count=281
+        )
+        assert hint is not None
+        assert hint["instead_of"] == "list_incidents"
+        assert hint["use"] == "collect_incidents"
+
+    def test_no_hint_when_no_more_pages(self):
+        assert (
+            _pagination_efficiency_hint(
+                page_size=1, has_more=False, total_pages=1, total_count=1
+            )
+            is None
+        )
+
+    def test_no_hint_at_or_above_efficient_page_size(self):
+        assert (
+            _pagination_efficiency_hint(
+                page_size=25, has_more=True, total_pages=50, total_count=1250
+            )
+            is None
+        )
+
+    def test_no_hint_for_short_sweep_under_threshold(self):
+        # small page_size but only a few pages to go — not worth nagging
+        assert (
+            _pagination_efficiency_hint(
+                page_size=5, has_more=True, total_pages=3, total_count=12
+            )
+            is None
+        )
+
+    def test_hint_fires_for_small_page_size_many_pages(self):
+        hint = _pagination_efficiency_hint(
+            page_size=10, has_more=True, total_pages=6, total_count=55
+        )
+        assert hint is not None
+
+    def test_handles_missing_total_pages(self):
+        assert (
+            _pagination_efficiency_hint(
+                page_size=1, has_more=True, total_pages=None, total_count=None
+            )
+            is None
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Two complementary changes that reduce token usage for the hosted Rootly MCP, consolidated into one PR.

## 1. Pagination efficiency hint (`list_incidents`)

MCPCat/Datadog traces show clients walking the full incident history one tiny page at a time (`page_size=1`) — a single sweep of 281 incidents = 281 tool calls. When `list_incidents` is called with a below-default `page_size` against a result set large enough to require many paginated calls, the response now includes an advisory `_use_tool` hint steering the caller to `collect_incidents` (bulk fetch in one call), a larger `page_size`, or filters. Reuses the existing `_use_tool` convention.

- **Non-breaking:** does not change returned data, status, or pagination — purely advisory.
- Fires only when it would actually save calls: `page_size < 25` **and** `has_more` **and** the sweep would exceed 5 paginated calls.
- `tools/incidents.py`: `_pagination_efficiency_hint` helper + wiring; tests cover all boundary conditions and the `list_incidents` integration.

## 2. Recommend Code Mode as the default hosted endpoint (README)

Code Mode (`/mcp-codemode`) exposes a compact set of meta-tools (`list_tools`, `tool_search`, `get_schema`, `tags`, `execute`) instead of ~200 individual tools, and lets the model chain `call_tool()` calls server-side in one `execute` block — dramatically lower token usage and fewer round-trips. Verified end-to-end including OAuth2 and Claude Desktop's tool-discovery flow.

- Lead the hosted transport options with **Code Mode (recommended)** + rationale callout; demote Streamable HTTP / SSE to alternatives.
- Lead the general remote setup and Claude Code quick-add with `/mcp-codemode`.
- **Warning** (proven in testing): connect Code Mode *instead of* the classic endpoints, not alongside — with both available, clients call the classic tools directly and skip `execute`, losing the savings.

## Testing
- Full unit suite passes; ruff + pyright clean.
- Docs counterpart for the Rootly docs site: rootlyhq/rootly-docs#514.

(Supersedes #152, which is folded in here.)