### PR TITLE
Add hosted reads-only tool profile (?tool_profile=reads)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Hosted tool profiles:
 
 - **Full (default):** use the URLs above as-is
 - **Slim (~70 tools):** add `?tool_profile=slim` to the hosted URL, for example `https://mcp.rootly.com/mcp?tool_profile=slim`
-- **Header alternative:** send `X-Rootly-Tool-Profile: slim`
-- **Server-wide default:** set `ROOTLY_MCP_HOSTED_TOOL_PROFILE=full|slim`
+- **Reads (read-only):** add `?tool_profile=reads` for the full read surface with every write/destructive tool hidden, for example `https://mcp.rootly.com/mcp?tool_profile=reads`. Unlike a hand-maintained allowlist it stays current automatically — new read tools are included the moment they ship. (Self-hosted equivalent: `ROOTLY_MCP_ENABLE_WRITE_TOOLS=false`.)
+- **Header alternative:** send `X-Rootly-Tool-Profile: slim` (or `reads`)
+- **Server-wide default:** set `ROOTLY_MCP_HOSTED_TOOL_PROFILE=full|slim` (`reads` is per-connection only)
 - **Exact custom override:** set `ROOTLY_MCP_ENABLED_TOOLS=...`
 
 ### General Remote Setup

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Hosted tool profiles:
 
 - **Full (default):** use the URLs above as-is
 - **Slim (~70 tools):** add `?tool_profile=slim` to the hosted URL, for example `https://mcp.rootly.com/mcp?tool_profile=slim`
-- **Reads (read-only):** add `?tool_profile=reads` for the full read surface with every write/destructive tool hidden, for example `https://mcp.rootly.com/mcp?tool_profile=reads`. Unlike a hand-maintained allowlist it stays current automatically — new read tools are included the moment they ship. (Self-hosted equivalent: `ROOTLY_MCP_ENABLE_WRITE_TOOLS=false`.)
+- **Reads (read-only):** add `?tool_profile=reads` for the full read surface with every write/destructive tool hidden, for example `https://mcp.rootly.com/mcp?tool_profile=reads`. Unlike a hand-maintained allowlist it stays current automatically — new read tools are included the moment they ship. (Self-hosted equivalent: `ROOTLY_MCP_ENABLE_WRITE_TOOLS=false`.) Note: this is a client-selected surface filter, not an authorization boundary — a caller with the same token can still select `full`. To *enforce* read-only access, scope the OAuth token/API key to read scopes.
 - **Header alternative:** send `X-Rootly-Tool-Profile: slim` (or `reads`)
 - **Server-wide default:** set `ROOTLY_MCP_HOSTED_TOOL_PROFILE=full|slim` (`reads` is per-connection only)
 - **Exact custom override:** set `ROOTLY_MCP_ENABLED_TOOLS=...`

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -808,9 +808,50 @@ def main():
         elif code_mode_server is not None:
             profiled_code_mode_servers[default_hosted_tool_profile] = code_mode_server
 
+        # Reads-only profile: the full read surface with every write/destructive
+        # tool hidden, selectable via ?tool_profile=reads (or the
+        # x-rootly-tool-profile header). It uses no name allowlist, so it stays
+        # current automatically as new read tools ship. Offered on the hosted
+        # streamable endpoint alongside the operator's full/slim profiles; skipped
+        # when the operator pins an explicit allowlist (their surface wins).
+        reads_server = None
+        if (
+            hosted_mode
+            and not explicit_enabled_tools
+            and normalized_transport in {"both", "streamable-http"}
+            and server_defaults.HOSTED_TOOL_PROFILE_READS not in profiled_servers
+        ):
+            reads_server = create_rootly_mcp_server(
+                swagger_path=args.swagger_path,
+                name=args.name,
+                allowed_paths=allowed_paths,
+                hosted=hosted_mode,
+                base_url=args.base_url,
+                transport=normalized_transport,
+                enable_write_tools=False,
+                enabled_tools=None,
+            )
+            profiled_servers[server_defaults.HOSTED_TOOL_PROFILE_READS] = reads_server
+
+            if code_mode_server is not None:
+                profiled_code_mode_servers.setdefault(default_hosted_tool_profile, code_mode_server)
+                profiled_code_mode_servers[server_defaults.HOSTED_TOOL_PROFILE_READS] = (
+                    create_rootly_codemode_server(
+                        swagger_path=args.swagger_path,
+                        name=f"{args.name} Code Mode",
+                        allowed_paths=allowed_paths,
+                        hosted=hosted_mode,
+                        base_url=args.base_url,
+                        enable_write_tools=False,
+                        enabled_tools=None,
+                    )
+                )
+
         maybe_enable_mcpcat_tracking(server, mcpcat_project_id, logger)
         if alternate_server is not None:
             maybe_enable_mcpcat_tracking(alternate_server, mcpcat_project_id, logger)
+        if reads_server is not None:
+            maybe_enable_mcpcat_tracking(reads_server, mcpcat_project_id, logger)
         if code_mode_server is not None:
             maybe_enable_mcpcat_tracking(code_mode_server, mcpcat_project_id, logger)
         for _profile, profiled_code_mode_server in profiled_code_mode_servers.items():

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -712,13 +712,15 @@ def main():
             args.enabled_tools, os.getenv(server_defaults.EnvVars.ENABLED_TOOLS)
         )
         default_hosted_tool_profile = server_defaults.hosted_tool_profile_from_env()
-        enabled_tools = (
-            {tool.strip() for tool in args.enabled_tools.split(",") if tool.strip()}
-            if args.enabled_tools
-            else enabled_tools_from_env(
-                hosted=hosted_mode,
-                hosted_tool_profile=default_hosted_tool_profile,
-            )
+        # Resolve through the same parser as `explicit_enabled_tools` so the two
+        # never disagree: the CLI allowlist wins only when it parses to a
+        # non-empty set. A truthy-but-empty CLI value (e.g. `--enabled-tools " , "`)
+        # falls through to the env/profile surface instead of silently clearing it.
+        enabled_tools = server_defaults.parse_tool_allowlist(
+            args.enabled_tools
+        ) or enabled_tools_from_env(
+            hosted=hosted_mode,
+            hosted_tool_profile=default_hosted_tool_profile,
         )
 
         logger.info(f"Initializing server with name: {args.name}")

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -704,8 +704,12 @@ def main():
         allowed_paths = None
         if args.allowed_paths:
             allowed_paths = [path.strip() for path in args.allowed_paths.split(",")]
-        explicit_enabled_tools = bool(args.enabled_tools) or (
-            os.getenv(server_defaults.EnvVars.ENABLED_TOOLS) is not None
+        # Only a *non-empty* allowlist pins the surface. A defined-but-empty
+        # ROOTLY_MCP_ENABLED_TOOLS (e.g. "" rendered by a deploy template) yields
+        # no allowlist and must not suppress the slim/reads profiles — otherwise a
+        # ?tool_profile=reads request would silently fall back to write-capable.
+        explicit_enabled_tools = server_defaults.has_explicit_tool_allowlist(
+            args.enabled_tools, os.getenv(server_defaults.EnvVars.ENABLED_TOOLS)
         )
         default_hosted_tool_profile = server_defaults.hosted_tool_profile_from_env()
         enabled_tools = (

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -12,12 +12,23 @@ logger = logging.getLogger(__name__)
 
 HOSTED_TOOL_PROFILE_SLIM = "slim"
 HOSTED_TOOL_PROFILE_FULL = "full"
+# Reads-only profile: the full read surface with every write/destructive tool
+# hidden. Unlike a name allowlist it stays current automatically — new read
+# tools are included the moment they ship, because the filter keys off the
+# read/write classification, not a hand-maintained list.
+HOSTED_TOOL_PROFILE_READS = "reads"
 _HOSTED_TOOL_PROFILE_ALIASES = {
     "core": HOSTED_TOOL_PROFILE_SLIM,
     "default": HOSTED_TOOL_PROFILE_FULL,
     "slim": HOSTED_TOOL_PROFILE_SLIM,
     "full": HOSTED_TOOL_PROFILE_FULL,
     "all": HOSTED_TOOL_PROFILE_FULL,
+    "reads": HOSTED_TOOL_PROFILE_READS,
+    "read": HOSTED_TOOL_PROFILE_READS,
+    "readonly": HOSTED_TOOL_PROFILE_READS,
+    "read-only": HOSTED_TOOL_PROFILE_READS,
+    "reads-only": HOSTED_TOOL_PROFILE_READS,
+    "reads_only": HOSTED_TOOL_PROFILE_READS,
 }
 
 
@@ -225,6 +236,19 @@ def hosted_tool_profile_from_env(default: str = HOSTED_TOOL_PROFILE_FULL) -> str
             raw,
             normalized,
         )
+    # `reads` is a per-connection selection (?tool_profile=reads), not a coherent
+    # operator default: the default-server build path can't express "hide writes".
+    # Coerce it to `full` so a misconfigured default never silently serves the
+    # wrong surface; clients can still request reads per connection.
+    if normalized == HOSTED_TOOL_PROFILE_READS:
+        logger.warning(
+            "%s=%r selects the reads-only profile, which is only available as a "
+            "per-connection selection (?tool_profile=reads); using %r as the default surface.",
+            EnvVars.HOSTED_TOOL_PROFILE,
+            raw,
+            HOSTED_TOOL_PROFILE_FULL,
+        )
+        return HOSTED_TOOL_PROFILE_FULL
     return normalized
 
 
@@ -256,7 +280,9 @@ def enabled_tools_from_env(
     if configured is not None:
         return configured
     if hosted:
-        if hosted_tool_profile == HOSTED_TOOL_PROFILE_FULL:
+        # `reads` exposes the full read surface (no name allowlist); its writes
+        # are hidden separately via enable_write_tools=False, not here.
+        if hosted_tool_profile in (HOSTED_TOOL_PROFILE_FULL, HOSTED_TOOL_PROFILE_READS):
             return None
         return set(DEFAULT_HOSTED_ENABLED_TOOLS)
     return None

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -57,6 +57,16 @@ def _parse_csv_set(raw: str | None) -> set[str] | None:
     return parsed or None
 
 
+def parse_tool_allowlist(raw: str | None) -> set[str] | None:
+    """Parse a comma-separated tool allowlist into a set (``None`` if empty).
+
+    A value that is a non-empty string but contains no real entries (``" , "``,
+    whitespace) parses to ``None`` — the same as unset — so callers can treat
+    "no effective allowlist" uniformly regardless of the raw string shape.
+    """
+    return _parse_csv_set(raw)
+
+
 def has_explicit_tool_allowlist(*values: str | None) -> bool:
     """Whether any value pins a *non-empty* tool allowlist.
 

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -57,6 +57,18 @@ def _parse_csv_set(raw: str | None) -> set[str] | None:
     return parsed or None
 
 
+def has_explicit_tool_allowlist(*values: str | None) -> bool:
+    """Whether any value pins a *non-empty* tool allowlist.
+
+    Presence alone is not enough: a defined-but-empty value (``""``,
+    whitespace, or ``" , ,"`` from a deploy template) parses to no allowlist
+    and must not be treated as an operator-pinned surface — otherwise it would
+    silently suppress the slim/reads profiles and let a ``?tool_profile=reads``
+    request fall back to the write-capable default.
+    """
+    return any(_parse_csv_set(value) for value in values)
+
+
 # Default hosted tool surface tuned from one month of production popularity data.
 # This keeps the slim remote/serverless profile near 70 tools while still
 # covering the overwhelming majority of observed requests. Operators can always

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -663,6 +663,53 @@ def test_main_hosted_streamable_http_passes_stateless_default():
     assert mock_run.call_args.kwargs["default_tool_profile"] == "full"
 
 
+def test_main_empty_enabled_tools_env_does_not_suppress_reads_profile():
+    # A defined-but-empty ROOTLY_MCP_ENABLED_TOOLS must not be treated as an
+    # explicit allowlist: the slim/reads profiles are still built, so a
+    # ?tool_profile=reads request keeps its read-only isolation.
+    args = SimpleNamespace(
+        swagger_path=None,
+        log_level="ERROR",
+        name="Rootly",
+        transport="streamable-http",
+        debug=False,
+        base_url=None,
+        allowed_paths=None,
+        hosted=True,
+        enable_code_mode=False,
+        enable_write_tools=True,
+        enabled_tools=None,
+        list_tools=False,
+        code_mode_path=None,
+        host=False,
+    )
+    main_server = SimpleNamespace()
+    slim_server = SimpleNamespace()
+    reads_server = SimpleNamespace()
+
+    with patch.dict("os.environ", {"ROOTLY_MCP_ENABLED_TOOLS": "  "}, clear=True):
+        with patch("rootly_mcp_server.__main__.parse_args", return_value=args):
+            with patch("rootly_mcp_server.__main__.setup_logging"):
+                with patch(
+                    "rootly_mcp_server.__main__.create_rootly_mcp_server",
+                    side_effect=[main_server, slim_server, reads_server],
+                ):
+                    with patch(
+                        "rootly_mcp_server.__main__.get_hosted_auth_middleware", return_value=[]
+                    ):
+                        with patch(
+                            "rootly_mcp_server.__main__.run_profiled_streamable_http_server"
+                        ) as mock_run:
+                            main()
+
+    mock_run.assert_called_once()
+    assert mock_run.call_args.kwargs["profiled_servers"] == {
+        "full": main_server,
+        "slim": slim_server,
+        "reads": reads_server,
+    }
+
+
 def test_main_hosted_streamable_http_uses_slim_as_default_when_requested_by_env():
     args = SimpleNamespace(
         swagger_path=None,

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -293,6 +293,24 @@ def test_resolve_requested_hosted_tool_profile_falls_back_to_default_on_unknown_
     assert profile == "slim"
 
 
+def test_resolve_requested_hosted_tool_profile_resolves_reads_from_query_param():
+    profile = resolve_requested_hosted_tool_profile(
+        query_params={"tool_profile": "reads"},
+        headers={},
+    )
+
+    assert profile == "reads"
+
+
+def test_resolve_requested_hosted_tool_profile_resolves_reads_alias_from_header():
+    profile = resolve_requested_hosted_tool_profile(
+        query_params={},
+        headers={"x-rootly-tool-profile": "read-only"},
+    )
+
+    assert profile == "reads"
+
+
 def test_streamable_http_defaults_hosted_mode_to_stateless_when_unset():
     with patch.dict("os.environ", {}, clear=True):
         assert streamable_http_stateless_enabled(hosted=True, fastmcp_stateless_http=False) is True
@@ -618,13 +636,14 @@ def test_main_hosted_streamable_http_passes_stateless_default():
     )
     main_server = SimpleNamespace()
     slim_server = SimpleNamespace()
+    reads_server = SimpleNamespace()
 
     with patch.dict("os.environ", {}, clear=True):
         with patch("rootly_mcp_server.__main__.parse_args", return_value=args):
             with patch("rootly_mcp_server.__main__.setup_logging"):
                 with patch(
                     "rootly_mcp_server.__main__.create_rootly_mcp_server",
-                    side_effect=[main_server, slim_server],
+                    side_effect=[main_server, slim_server, reads_server],
                 ):
                     with patch(
                         "rootly_mcp_server.__main__.get_hosted_auth_middleware", return_value=[]
@@ -639,6 +658,7 @@ def test_main_hosted_streamable_http_passes_stateless_default():
     assert mock_run.call_args.kwargs["profiled_servers"] == {
         "full": main_server,
         "slim": slim_server,
+        "reads": reads_server,
     }
     assert mock_run.call_args.kwargs["default_tool_profile"] == "full"
 
@@ -662,13 +682,14 @@ def test_main_hosted_streamable_http_uses_slim_as_default_when_requested_by_env(
     )
     slim_server = SimpleNamespace()
     full_server = SimpleNamespace()
+    reads_server = SimpleNamespace()
 
     with patch.dict("os.environ", {"ROOTLY_MCP_HOSTED_TOOL_PROFILE": "slim"}, clear=True):
         with patch("rootly_mcp_server.__main__.parse_args", return_value=args):
             with patch("rootly_mcp_server.__main__.setup_logging"):
                 with patch(
                     "rootly_mcp_server.__main__.create_rootly_mcp_server",
-                    side_effect=[slim_server, full_server],
+                    side_effect=[slim_server, full_server, reads_server],
                 ):
                     with patch(
                         "rootly_mcp_server.__main__.get_hosted_auth_middleware", return_value=[]
@@ -683,6 +704,7 @@ def test_main_hosted_streamable_http_uses_slim_as_default_when_requested_by_env(
     assert mock_run.call_args.kwargs["profiled_servers"] == {
         "slim": slim_server,
         "full": full_server,
+        "reads": reads_server,
     }
     assert mock_run.call_args.kwargs["default_tool_profile"] == "slim"
 
@@ -748,19 +770,25 @@ def test_main_tracks_main_and_code_mode_servers_when_mcpcat_project_id_set():
     )
     main_server = SimpleNamespace()
     slim_server = SimpleNamespace()
+    reads_server = SimpleNamespace()
     code_mode_server = SimpleNamespace()
     slim_code_mode_server = SimpleNamespace()
+    reads_code_mode_server = SimpleNamespace()
 
     with patch.dict("os.environ", {"ROOTLY_MCPCAT_PROJECT_ID": "proj_test_123"}, clear=True):
         with patch("rootly_mcp_server.__main__.parse_args", return_value=args):
             with patch("rootly_mcp_server.__main__.setup_logging"):
                 with patch(
                     "rootly_mcp_server.__main__.create_rootly_mcp_server",
-                    side_effect=[main_server, slim_server],
+                    side_effect=[main_server, slim_server, reads_server],
                 ):
                     with patch(
                         "rootly_mcp_server.__main__.create_rootly_codemode_server",
-                        side_effect=[code_mode_server, slim_code_mode_server],
+                        side_effect=[
+                            code_mode_server,
+                            slim_code_mode_server,
+                            reads_code_mode_server,
+                        ],
                     ):
                         with patch("rootly_mcp_server.__main__.run_dual_http_server"):
                             with patch(
@@ -768,11 +796,15 @@ def test_main_tracks_main_and_code_mode_servers_when_mcpcat_project_id_set():
                             ) as mock_track:
                                 main()
 
-    assert len(mock_track.call_args_list) == 4
+    # main + slim + reads server profiles, then code-mode servers for each
+    # profile (the default code-mode server plus the slim and reads variants).
+    assert len(mock_track.call_args_list) == 6
     assert mock_track.call_args_list[0].args[:2] == (main_server, "proj_test_123")
     assert mock_track.call_args_list[1].args[:2] == (slim_server, "proj_test_123")
-    assert mock_track.call_args_list[2].args[:2] == (code_mode_server, "proj_test_123")
-    assert mock_track.call_args_list[3].args[:2] == (slim_code_mode_server, "proj_test_123")
+    assert mock_track.call_args_list[2].args[:2] == (reads_server, "proj_test_123")
+    assert mock_track.call_args_list[3].args[:2] == (code_mode_server, "proj_test_123")
+    assert mock_track.call_args_list[4].args[:2] == (slim_code_mode_server, "proj_test_123")
+    assert mock_track.call_args_list[5].args[:2] == (reads_code_mode_server, "proj_test_123")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -150,7 +150,11 @@ def test_main_write_tools_hosted_path_respects_flag_then_env(flag, env, expected
                             main()
 
     # every profile server is built with the resolved value
-    assert mock_create.call_args.kwargs["enable_write_tools"] is expected
+    # Assert on the FIRST create call (the operator-facing server). The hosted
+    # path also builds slim and reads profile servers afterwards, and the reads
+    # profile is intentionally constructed with enable_write_tools=False, so
+    # call_args (the last call) would report that instead.
+    assert mock_create.call_args_list[0].kwargs["enable_write_tools"] is expected
 
 
 def test_get_server_passes_enabled_tools_env_flag():
@@ -708,6 +712,50 @@ def test_main_empty_enabled_tools_env_does_not_suppress_reads_profile():
         "slim": slim_server,
         "reads": reads_server,
     }
+
+
+def test_main_empty_cli_allowlist_does_not_discard_env_allowlist():
+    # `--enabled-tools " , "` is a truthy string that parses to no entries. It
+    # must not clear a real ROOTLY_MCP_ENABLED_TOOLS allowlist (which would build
+    # the write-capable full surface) — the env allowlist wins.
+    args = SimpleNamespace(
+        swagger_path=None,
+        log_level="ERROR",
+        name="Rootly",
+        transport="streamable-http",
+        debug=False,
+        base_url=None,
+        allowed_paths=None,
+        hosted=True,
+        enable_code_mode=False,
+        enable_write_tools=True,
+        enabled_tools=" , ",
+        list_tools=False,
+        code_mode_path=None,
+        host=False,
+    )
+    main_server = SimpleNamespace(run=Mock())
+
+    with patch.dict("os.environ", {"ROOTLY_MCP_ENABLED_TOOLS": "list_incidents"}, clear=True):
+        with patch("rootly_mcp_server.__main__.parse_args", return_value=args):
+            with patch("rootly_mcp_server.__main__.setup_logging"):
+                with patch(
+                    "rootly_mcp_server.__main__.create_rootly_mcp_server",
+                    return_value=main_server,
+                ) as mock_create:
+                    with patch(
+                        "rootly_mcp_server.__main__.get_hosted_auth_middleware", return_value=[]
+                    ):
+                        with patch(
+                            "rootly_mcp_server.__main__.run_profiled_streamable_http_server"
+                        ) as mock_profiled_run:
+                            main()
+
+    # env allowlist honored (not cleared by the empty CLI value); pinned surface
+    # means no profiled reads/slim servers are built.
+    assert mock_create.call_args.kwargs["enabled_tools"] == {"list_incidents"}
+    mock_profiled_run.assert_not_called()
+    main_server.run.assert_called_once()
 
 
 def test_main_hosted_streamable_http_uses_slim_as_default_when_requested_by_env():

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1714,3 +1714,74 @@ class TestApplyAnnotationsToAutogenTools:
         assert tools["list_items"].annotations.readOnlyHint is True
         assert tools["create_item"].annotations.readOnlyHint is False
         assert tools["delete_item"].annotations.destructiveHint is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestReadsProfileSurface:
+    """The hosted `reads` profile == full read surface with writes hidden.
+
+    The profile is built with ``enable_write_tools=False`` and no name
+    allowlist, so it stays current automatically: any newly shipped read tool
+    is included, while every write/destructive tool is filtered out.
+    """
+
+    # Write-ish tool names that are actually read-only (annotated readOnlyHint)
+    # and therefore legitimately remain in the reads surface despite the prefix.
+    _READ_ONLY_WRITE_PREFIXED = {"create_override_recommendation"}
+    _WRITE_PREFIXES = ("create_", "update_", "delete_", "attach_", "remove_", "add_")
+
+    def _reads_server(self):
+        return create_rootly_mcp_server(hosted=True, enable_write_tools=False, enabled_tools=None)
+
+    def _full_server(self):
+        return create_rootly_mcp_server(hosted=True, enable_write_tools=True, enabled_tools=None)
+
+    async def test_reads_profile_exposes_representative_read_tools(self, mock_environment_token):
+        tools = {t.name for t in await self._reads_server().list_tools()}
+
+        for name in (
+            "list_incidents",
+            "get_incident",
+            "search_incidents",
+            "find_related_incidents",
+            "list_workflow_tasks",
+            "get_workflow_task",
+        ):
+            assert name in tools, f"expected read tool {name!r} missing from reads profile"
+
+    async def test_reads_profile_hides_write_tools(self, mock_environment_token):
+        tools = {t.name for t in await self._reads_server().list_tools()}
+
+        for name in (
+            "create_incident",
+            "update_incident",
+            "create_workflow_task",
+            "update_workflow_task",
+            "create_incident_action_item",
+            "update_incident_form_field_selection",
+        ):
+            assert name not in tools, f"write tool {name!r} leaked into reads profile"
+
+    async def test_reads_profile_has_no_mutating_tools(self, mock_environment_token):
+        """Regression guard: nothing that mutates state should survive.
+
+        Any write-prefixed tool present must be an explicitly known read-only
+        tool (e.g. ``create_override_recommendation``, which only recommends).
+        A new genuine write tool added without a write guard would trip this.
+        """
+        tools = {t.name for t in await self._reads_server().list_tools()}
+
+        leaked = {
+            name
+            for name in tools
+            if name.startswith(self._WRITE_PREFIXES) and name not in self._READ_ONLY_WRITE_PREFIXED
+        }
+        assert leaked == set(), f"mutating tools leaked into reads profile: {sorted(leaked)}"
+
+    async def test_reads_profile_is_strict_subset_of_full(self, mock_environment_token):
+        reads = {t.name for t in await self._reads_server().list_tools()}
+        full = {t.name for t in await self._full_server().list_tools()}
+
+        assert reads < full, "reads profile must be a strict subset of the full surface"
+        assert not (reads - full), f"reads exposed tools absent from full: {sorted(reads - full)}"

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1785,3 +1785,31 @@ class TestReadsProfileSurface:
 
         assert reads < full, "reads profile must be a strict subset of the full surface"
         assert not (reads - full), f"reads exposed tools absent from full: {sorted(reads - full)}"
+
+    async def test_reads_profile_every_tool_is_annotated_read_only(self, mock_environment_token):
+        """Name-independent guard: no tool in the reads surface may be mutating.
+
+        Stronger than the write-prefix check — a future mutating tool with a
+        non-write-ish name (e.g. ``escalate_incident``) would still be caught
+        here via its ``readOnlyHint=False`` / ``destructiveHint=True`` annotation.
+        """
+        tools = await self._reads_server().list_tools()
+
+        offenders = [
+            t.name
+            for t in tools
+            if t.annotations
+            and (t.annotations.readOnlyHint is False or t.annotations.destructiveHint is True)
+        ]
+        assert offenders == [], f"non-read-only tools in reads profile: {sorted(offenders)}"
+
+    async def test_reads_server_cannot_resolve_write_tools(self, mock_environment_token):
+        """Code Mode safety: ``execute`` dispatches through this server's
+        ``call_tool``, so a write tool must be unresolvable here — otherwise
+        ``/mcp-codemode?tool_profile=reads`` could invoke writes via execute."""
+        from fastmcp.exceptions import NotFoundError
+
+        server = self._reads_server()
+        for write_tool in ("create_incident", "update_incident", "delete_incident"):
+            with pytest.raises(NotFoundError):
+                await server.call_tool(write_tool, {})

--- a/tests/unit/test_server_defaults_module.py
+++ b/tests/unit/test_server_defaults_module.py
@@ -6,6 +6,7 @@ from rootly_mcp_server.server_defaults import (
     DEFAULT_ALLOWED_PATHS,
     DEFAULT_HOSTED_ENABLED_TOOLS,
     HOSTED_TOOL_PROFILE_FULL,
+    HOSTED_TOOL_PROFILE_READS,
     HOSTED_TOOL_PROFILE_SLIM,
     _generate_recommendation,
     enabled_tools_from_env,
@@ -125,8 +126,36 @@ class TestServerDefaultsModule:
         assert normalize_hosted_tool_profile("default") == HOSTED_TOOL_PROFILE_FULL
         assert normalize_hosted_tool_profile("all") == HOSTED_TOOL_PROFILE_FULL
 
+    def test_normalize_hosted_tool_profile_accepts_reads_aliases(self):
+        for alias in ("reads", "read", "readonly", "read-only", "reads-only", "reads_only"):
+            assert normalize_hosted_tool_profile(alias) == HOSTED_TOOL_PROFILE_READS
+        # Case-insensitive, like the other profiles.
+        assert normalize_hosted_tool_profile("READS") == HOSTED_TOOL_PROFILE_READS
+
+    def test_enabled_tools_from_env_reads_profile_keeps_full_read_surface(self):
+        # `reads` uses no name allowlist — writes are hidden via
+        # enable_write_tools=False, not by pruning the allowlist here.
+        with patch.dict("os.environ", {}, clear=True):
+            assert (
+                enabled_tools_from_env(
+                    hosted=True,
+                    hosted_tool_profile=HOSTED_TOOL_PROFILE_READS,
+                )
+                is None
+            )
+
     def test_hosted_tool_profile_from_env_defaults_to_full(self):
         with patch.dict("os.environ", {}, clear=True):
+            assert hosted_tool_profile_from_env() == HOSTED_TOOL_PROFILE_FULL
+
+    def test_hosted_tool_profile_from_env_coerces_reads_default_to_full(self):
+        # `reads` is only meaningful as a per-connection selection; as an operator
+        # default it can't express "hide writes", so it degrades to `full`.
+        with patch.dict(
+            "os.environ",
+            {"ROOTLY_MCP_HOSTED_TOOL_PROFILE": "reads"},
+            clear=True,
+        ):
             assert hosted_tool_profile_from_env() == HOSTED_TOOL_PROFILE_FULL
 
     def test_default_hosted_enabled_tools_are_all_snake_case(self):

--- a/tests/unit/test_server_defaults_module.py
+++ b/tests/unit/test_server_defaults_module.py
@@ -10,6 +10,7 @@ from rootly_mcp_server.server_defaults import (
     HOSTED_TOOL_PROFILE_SLIM,
     _generate_recommendation,
     enabled_tools_from_env,
+    has_explicit_tool_allowlist,
     hosted_tool_profile_from_env,
     normalize_hosted_tool_profile,
     resolve_write_tools_enabled,
@@ -147,6 +148,17 @@ class TestServerDefaultsModule:
     def test_hosted_tool_profile_from_env_defaults_to_full(self):
         with patch.dict("os.environ", {}, clear=True):
             assert hosted_tool_profile_from_env() == HOSTED_TOOL_PROFILE_FULL
+
+    def test_has_explicit_tool_allowlist_true_only_for_non_empty(self):
+        # A real allowlist pins the surface...
+        assert has_explicit_tool_allowlist("list_incidents") is True
+        assert has_explicit_tool_allowlist(None, "get_incident,list_teams") is True
+        # ...but presence of a defined-but-empty value does not.
+        assert has_explicit_tool_allowlist(None, None) is False
+        assert has_explicit_tool_allowlist("") is False
+        assert has_explicit_tool_allowlist("   ") is False
+        assert has_explicit_tool_allowlist(" , ,") is False
+        assert has_explicit_tool_allowlist("", "") is False
 
     def test_hosted_tool_profile_from_env_coerces_reads_default_to_full(self):
         # `reads` is only meaningful as a per-connection selection; as an operator


### PR DESCRIPTION
## Summary

Adds a **`reads`** hosted tool profile, selectable per connection via `?tool_profile=reads` (or `X-Rootly-Tool-Profile: reads`), alongside the existing `full`/`slim` profiles. It exposes the **full read surface with every write/destructive tool hidden**, built with `enable_write_tools=False` and **no name allowlist** — so it stays current automatically as new read tools ship.

## Why

Requested by a security-conscious customer (DoorDash, Pylon #30250) who wanted read-scoped MCP access from the remote endpoint without hand-maintaining an exact-name allowlist that drifts stale as the tool surface grows.

Before this, the options were:
- **Exact-name allowlist** (`ROOTLY_MCP_ENABLED_TOOLS`) — goes stale every time we ship a new tool, and a `list*,get*`-style pattern would silently miss non-`get`/`list` reads (`search_incidents`, `find_related_incidents`, `suggest_solutions`, ...).
- **`ROOTLY_MCP_ENABLE_WRITE_TOOLS=false`** — correct and auto-current, but **self-host only**; not reachable on the hosted endpoint, whose only knob was the full-vs-slim profile.

The `reads` profile keys off the existing read/write classification (not a name list), so it is **zero-maintenance, always current, and least-privilege by construction** — and it reuses the per-connection profile selector already in place, so it's a one-line change for clients (add `?tool_profile=reads` to the URL).

## What changed

- **`server_defaults.py`**
  - Add `HOSTED_TOOL_PROFILE_READS` + aliases (`read`, `readonly`, `read-only`, `reads-only`, `reads_only`).
  - `enabled_tools_from_env` treats `reads` as the full read surface (no allowlist; writes are hidden via `enable_write_tools=False`, not here).
  - `hosted_tool_profile_from_env` coerces an *operator default* of `reads` back to `full` with a warning — `reads` is only coherent as a per-connection selection, so a misconfigured default never silently serves the wrong surface.
- **`__main__.py`** — build the `reads` profile (and its Code Mode variant) on the hosted streamable endpoint; skipped when an operator pins an explicit allowlist (their surface wins).
- **`README.md`** — document the profile.

## Validation

- **Live end-to-end over HTTP** (`?tool_profile=reads` vs `full`): reads is a **strict subset** of full (140 vs 252 tools), every `create_/update_/delete_` tool hidden, **no mutating tool leaks** (`create_override_recommendation` legitimately stays — it's `readOnlyHint=True`), and `default` (no param) == `full`.
- **Unit tests added**: profile alias resolution, `enabled_tools_from_env`/`hosted_tool_profile_from_env` behavior (incl. reads→full coercion), `resolve_requested_hosted_tool_profile` for query param + header, and a reads-profile surface test class (representative reads present, writes hidden, no mutating tools, strict subset of full). Existing `main()` profile tests updated for the added instance.
- Full suite: **578 passed, 13 skipped**. `ruff check` + `ruff format --check` clean.

## Notes

- No behavior change to `full`/`slim`, or when an explicit `ROOTLY_MCP_ENABLED_TOOLS` allowlist is set.
- Also available on the Code Mode endpoint: `https://mcp.rootly.com/mcp-codemode?tool_profile=reads`.
