### PR TITLE
Scrub credential-named arguments via AgentCat's event hook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN uv pip install --system --no-cache-dir -e .
 # fit for our stateless hosted transport. Our integration code is unchanged.
 # In case AgentCat constrains Pydantic, we restore the server's pinned version
 # after installation.
-RUN uv pip install --system --no-cache-dir "agentcat[community]==2.0.1" \
+RUN uv pip install --system --no-cache-dir "agentcat[community]==2.0.2" \
     && uv pip install --system --no-cache-dir pydantic==2.13.4
 
 # Create non-root user

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -167,6 +167,13 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
         # would turn that into telemetry being switched off entirely.
         if agentcat_options_supports(agentcat_types.AgentCatOptions, "redact_event"):
             options_kwargs["redact_event"] = scrub_event_arguments
+        else:
+            # Say so rather than degrade quietly. The scrubber being silently
+            # inactive is how the SENTRY_DSN gap went unnoticed for months.
+            logger.warning(
+                "AgentCat does not support redact_event; credential-named tool "
+                "arguments will not be scrubbed. Upgrade to 2.0.2 or later."
+            )
         if sentry_dsn:
             options_kwargs["exporters"] = {
                 "sentry": {

--- a/src/rootly_mcp_server/__main__.py
+++ b/src/rootly_mcp_server/__main__.py
@@ -7,6 +7,7 @@ This module provides the main entry point for the Rootly MCP Server.
 
 import argparse
 import asyncio
+import dataclasses
 import importlib
 import logging
 import os
@@ -31,7 +32,7 @@ from .server_defaults import (
     enabled_tools_from_env,
     resolve_write_tools_enabled,
 )
-from .telemetry_scrubber import redact_agentcat_telemetry_text
+from .telemetry_scrubber import redact_agentcat_telemetry_text, scrub_event_arguments
 from .transport import get_hosted_authenticated_user
 
 TransportName = Literal["stdio", "sse", "streamable-http", "both"]
@@ -104,6 +105,21 @@ def resolve_requested_hosted_tool_profile(
     return server_defaults.normalize_hosted_tool_profile(raw, default=default)
 
 
+def agentcat_options_supports(options_cls: type[Any], option: str) -> bool:
+    """Whether the installed AgentCat accepts *option*.
+
+    Options are a dataclass, so the accepted set is introspectable. Feature
+    detection keeps a newer hook from disabling telemetry on an older SDK,
+    which is what an unexpected keyword would cause.
+    """
+    try:
+        return option in {field.name for field in dataclasses.fields(options_cls)}
+    except TypeError:
+        # Not a dataclass in this version -- assume unsupported rather than
+        # risk the TypeError path.
+        return False
+
+
 def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging.Logger) -> None:
     """Enable AgentCat tracking when configured and available.
 
@@ -144,6 +160,13 @@ def maybe_enable_mcpcat_tracking(server, project_id: str | None, logger: logging
             # configuration sends credentials unscrubbed.
             "redact_sensitive_information": redact_agentcat_telemetry_text,
         }
+        # The event-level hook is the only place a credential's field name is
+        # visible; the string hook above receives bare values. It landed after
+        # 2.0.1, so it is offered only when the installed SDK accepts it --
+        # passing an unknown option raises TypeError, and the except below
+        # would turn that into telemetry being switched off entirely.
+        if agentcat_options_supports(agentcat_types.AgentCatOptions, "redact_event"):
+            options_kwargs["redact_event"] = scrub_event_arguments
         if sentry_dsn:
             options_kwargs["exporters"] = {
                 "sentry": {

--- a/src/rootly_mcp_server/telemetry_scrubber.py
+++ b/src/rootly_mcp_server/telemetry_scrubber.py
@@ -253,6 +253,10 @@ def scrub_event_arguments(event: Any) -> Any:
             }
         if isinstance(node, list):
             return [walk(item, depth + 1) for item in node]
+        if isinstance(node, tuple):
+            # JSON cannot produce one, but a credential inside a tuple would
+            # otherwise be published: the SDK's own walker skips them too.
+            return tuple(walk(item, depth + 1) for item in node)
         return node
 
     parameters = getattr(event, "parameters", None)

--- a/src/rootly_mcp_server/telemetry_scrubber.py
+++ b/src/rootly_mcp_server/telemetry_scrubber.py
@@ -219,6 +219,12 @@ TELEMETRY_REDACTIONS: tuple[tuple[re.Pattern[str], Any], ...] = (
 )
 
 
+# Depth past which an argument subtree is replaced instead of walked. AgentCat
+# truncates events to depth 5 anyway, and this runs before that, so the limit is
+# generous -- it exists to bound the walk, not to shape the payload.
+_MAX_ARGUMENT_DEPTH = 32
+
+
 def scrub_event_arguments(event: Any) -> Any:
     """Scrub credential-named arguments from an event, keys included.
 
@@ -232,19 +238,26 @@ def scrub_event_arguments(event: Any) -> Any:
     keys to read, so they stay with the string scrubber.
     """
 
-    def walk(node: Any) -> Any:
+    def walk(node: Any, depth: int) -> Any:
+        # Past the limit the subtree is replaced rather than descended into.
+        # Arguments are attacker-shaped JSON, and an unbounded walk raises
+        # RecursionError on deep nesting or on a cycle -- which AgentCat turns
+        # into a dropped event. Replacing keeps the failure on the safe side:
+        # a value is never published just because it was buried deeply.
+        if depth > _MAX_ARGUMENT_DEPTH:
+            return REDACTED
         if isinstance(node, dict):
             return {
-                key: REDACTED if is_credential_key(str(key)) else walk(value)
+                key: REDACTED if is_credential_key(str(key)) else walk(value, depth + 1)
                 for key, value in node.items()
             }
         if isinstance(node, list):
-            return [walk(item) for item in node]
+            return [walk(item, depth + 1) for item in node]
         return node
 
     parameters = getattr(event, "parameters", None)
     if parameters:
-        event.parameters = walk(parameters)
+        event.parameters = walk(parameters, 0)
     return event
 
 

--- a/src/rootly_mcp_server/telemetry_scrubber.py
+++ b/src/rootly_mcp_server/telemetry_scrubber.py
@@ -219,6 +219,35 @@ TELEMETRY_REDACTIONS: tuple[tuple[re.Pattern[str], Any], ...] = (
 )
 
 
+def scrub_event_arguments(event: Any) -> Any:
+    """Scrub credential-named arguments from an event, keys included.
+
+    Registered as AgentCat's `redact_event` hook, which -- unlike
+    `redact_sensitive_information` -- receives the whole event rather than one
+    string at a time. That is the only place the field name is visible: the SDK
+    walks the argument dict and hands the string hook bare values, so `hunter2`
+    arrives with nothing to say it came from a field called `password`.
+
+    Only `parameters` is touched. `response` and `error` are free text with no
+    keys to read, so they stay with the string scrubber.
+    """
+
+    def walk(node: Any) -> Any:
+        if isinstance(node, dict):
+            return {
+                key: REDACTED if is_credential_key(str(key)) else walk(value)
+                for key, value in node.items()
+            }
+        if isinstance(node, list):
+            return [walk(item) for item in node]
+        return node
+
+    parameters = getattr(event, "parameters", None)
+    if parameters:
+        event.parameters = walk(parameters)
+    return event
+
+
 class TelemetryScrubber:
     """Removes credentials from telemetry strings, preserving everything else."""
 

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -594,7 +594,10 @@ def test_maybe_enable_mcpcat_tracking_logs_when_track_raises():
         maybe_enable_mcpcat_tracking(server, "proj_test_123", logger)
 
     assert agentcat_module.track.call_args.args[:2] == (server, "proj_test_123")
-    logger.warning.assert_called_once_with(
+    # assert_any_call, not assert_called_once_with: this stub's options class has
+    # no redact_event field, so the unsupported-SDK warning fires too. This test
+    # is about the track() failure path.
+    logger.warning.assert_any_call(
         "AgentCat tracking could not be enabled; skipping (%s)",
         "RuntimeError",
     )

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -1,6 +1,7 @@
 """Tests for CLI transport normalization and config propagation in __main__."""
 
 import argparse
+import dataclasses
 from types import ModuleType, SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
@@ -10,6 +11,7 @@ from starlette.requests import Request
 
 from rootly_mcp_server.__main__ import (
     _get_sorted_tool_names,
+    agentcat_options_supports,
     build_mcpcat_identify_callback,
     get_server,
     main,
@@ -370,6 +372,62 @@ def test_scrubber_is_registered_whenever_telemetry_is_enabled(
 
     assert captured.get("redact_sensitive_information") is redact_agentcat_telemetry_text
     assert ("exporters" in captured) is expect_exporters
+
+
+@pytest.mark.parametrize("supported", [True, False])
+def test_redact_event_is_offered_only_when_the_sdk_accepts_it(supported, monkeypatch):
+    # The event hook landed after 2.0.1. Passing an unknown option raises
+    # TypeError, which maybe_enable_mcpcat_tracking catches by disabling
+    # telemetry outright -- so an older SDK must simply not be offered it.
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+    fields: dict[str, Any] = {
+        "identify": None,
+        "redact_sensitive_information": None,
+        "exporters": None,
+    }
+    if supported:
+        fields["redact_event"] = None
+    options_cls = dataclasses.make_dataclass(
+        "AgentCatOptions", [(name, Any, None) for name in fields]
+    )
+
+    captured: dict[str, Any] = {}
+
+    def make_options(**kwargs):
+        captured.update(kwargs)
+        return options_cls(**kwargs)
+
+    # A subclass keeps dataclasses.fields() working while letting the call
+    # record its kwargs, which a Mock wrapper would hide.
+    factory = type("Factory", (options_cls,), {"__new__": lambda cls, **kw: make_options(**kw)})
+
+    agentcat_module = SimpleNamespace(track=Mock())
+    agentcat_types_module = SimpleNamespace(
+        AgentCatOptions=factory,
+        UserIdentity=Mock(side_effect=lambda **kw: SimpleNamespace(**kw)),
+    )
+
+    def fake_import(name):
+        return agentcat_module if name == "agentcat" else agentcat_types_module
+
+    with patch("rootly_mcp_server.__main__.importlib.import_module", fake_import):
+        maybe_enable_mcpcat_tracking(object(), "proj_test_123", Mock())
+
+    # Telemetry stays enabled either way -- that is the point of the detection.
+    assert agentcat_module.track.called
+    assert captured["redact_sensitive_information"] is redact_agentcat_telemetry_text
+    assert ("redact_event" in captured) is supported
+
+
+def test_agentcat_options_supports_detects_the_field():
+    options_cls = dataclasses.make_dataclass("Opts", [("redact_event", Any, None)])
+    assert agentcat_options_supports(options_cls, "redact_event") is True
+    assert agentcat_options_supports(options_cls, "nope") is False
+
+
+def test_agentcat_options_supports_is_false_for_a_non_dataclass():
+    assert agentcat_options_supports(object, "redact_event") is False
 
 
 def test_maybe_enable_mcpcat_tracking_tracks_when_available():

--- a/tests/unit/test_main_transport.py
+++ b/tests/unit/test_main_transport.py
@@ -411,13 +411,19 @@ def test_redact_event_is_offered_only_when_the_sdk_accepts_it(supported, monkeyp
     def fake_import(name):
         return agentcat_module if name == "agentcat" else agentcat_types_module
 
+    logger = Mock()
     with patch("rootly_mcp_server.__main__.importlib.import_module", fake_import):
-        maybe_enable_mcpcat_tracking(object(), "proj_test_123", Mock())
+        maybe_enable_mcpcat_tracking(object(), "proj_test_123", logger)
 
     # Telemetry stays enabled either way -- that is the point of the detection.
     assert agentcat_module.track.called
     assert captured["redact_sensitive_information"] is redact_agentcat_telemetry_text
     assert ("redact_event" in captured) is supported
+
+    # An SDK too old for the hook must say so. Silently skipping the scrubber is
+    # how the SENTRY_DSN gap survived unnoticed.
+    warned = any("redact_event" in str(call.args[0]) for call in logger.warning.call_args_list)
+    assert warned is (not supported)
 
 
 def test_agentcat_options_supports_detects_the_field():

--- a/tests/unit/test_telemetry_scrubber.py
+++ b/tests/unit/test_telemetry_scrubber.py
@@ -493,3 +493,53 @@ class TestClientIdentificationSurvives:
         headers = scrub_event_arguments(event).parameters["arguments"]["headers"]
         assert headers["user-agent"] == "Odin/1.2.0"
         assert headers["authorization"] == "[redacted]"
+
+
+class TestEventHookHostileInput:
+    """Arguments are attacker-shaped JSON, and AgentCat drops an event whose
+    hook raises -- so a walk that blows the stack loses telemetry silently."""
+
+    def test_deeply_nested_arguments_do_not_raise(self):
+        node = root = {}
+        for _ in range(5000):
+            node["n"] = {}
+            node = node["n"]
+        node["password"] = "hunter2"
+        # No RecursionError; the event survives to be published.
+        scrub_event_arguments(SimpleNamespace(parameters={"arguments": root}))
+
+    def test_circular_arguments_terminate(self):
+        cycle: dict = {}
+        cycle["self"] = cycle
+        scrub_event_arguments(SimpleNamespace(parameters={"arguments": cycle}))
+
+    def test_a_credential_below_the_depth_limit_is_not_published(self):
+        # The subtree is replaced rather than descended into, so burying a
+        # credential deeply cannot smuggle it out.
+        node = root = {}
+        for _ in range(40):
+            node["n"] = {}
+            node = node["n"]
+        node["password"] = "DEEPSECRET"
+        result = scrub_event_arguments(SimpleNamespace(parameters={"arguments": root}))
+        assert "DEEPSECRET" not in str(result.parameters)
+
+    def test_ordinary_nesting_is_still_walked(self):
+        event = SimpleNamespace(
+            parameters={"arguments": {"a": {"b": {"c": {"password": "p", "id": "44"}}}}}
+        )
+        inner = scrub_event_arguments(event).parameters["arguments"]["a"]["b"]["c"]
+        assert inner == {"password": "[redacted]", "id": "44"}
+
+    @pytest.mark.parametrize("parameters", ["a string", 42, ["list"], None, {}])
+    def test_non_dict_parameters_are_returned_unchanged(self, parameters):
+        event = SimpleNamespace(parameters=parameters)
+        assert scrub_event_arguments(event).parameters == parameters
+
+    def test_non_string_keys_do_not_raise(self):
+        event = SimpleNamespace(parameters={"arguments": {1: "a", None: "b", ("t",): "c"}})
+        assert scrub_event_arguments(event).parameters["arguments"] == {
+            1: "a",
+            None: "b",
+            ("t",): "c",
+        }

--- a/tests/unit/test_telemetry_scrubber.py
+++ b/tests/unit/test_telemetry_scrubber.py
@@ -531,6 +531,15 @@ class TestEventHookHostileInput:
         inner = scrub_event_arguments(event).parameters["arguments"]["a"]["b"]["c"]
         assert inner == {"password": "[redacted]", "id": "44"}
 
+    def test_dicts_inside_tuples_are_walked(self):
+        # JSON cannot produce a tuple, but skipping them would publish a
+        # credential outright, and the SDK's own walker skips them too.
+        event = SimpleNamespace(parameters={"arguments": {"k": ({"password": "p"},), "id": "44"}})
+        args = scrub_event_arguments(event).parameters["arguments"]
+        assert args["k"] == ({"password": "[redacted]"},)
+        assert isinstance(args["k"], tuple)
+        assert args["id"] == "44"
+
     @pytest.mark.parametrize("parameters", ["a string", 42, ["list"], None, {}])
     def test_non_dict_parameters_are_returned_unchanged(self, parameters):
         event = SimpleNamespace(parameters=parameters)

--- a/tests/unit/test_telemetry_scrubber.py
+++ b/tests/unit/test_telemetry_scrubber.py
@@ -6,11 +6,14 @@ failure this module was written to fix, so the "must survive" cases below carry
 as much weight as the "must be removed" ones.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from rootly_mcp_server.telemetry_scrubber import (
     is_credential_key,
     redact_agentcat_telemetry_text,
+    scrub_event_arguments,
 )
 
 
@@ -397,3 +400,55 @@ class TestTelemetryRedactionRules:
             '{{"refresh_token": "{s}"}}',
         ):
             assert secret not in redact_agentcat_telemetry_text(template.format(s=secret))
+
+
+class TestScrubEventArguments:
+    """The event-level hook, which is the only place field names are visible.
+
+    `redact_sensitive_information` receives bare values, so a credential-named
+    argument cannot be recognised there. This hook gets the whole event.
+    """
+
+    @staticmethod
+    def _event(parameters):
+        return SimpleNamespace(parameters=parameters)
+
+    def test_credential_named_arguments_are_removed(self):
+        event = self._event(
+            {"arguments": {"incident_id": "44", "password": "hunter2", "api_key": "k"}}
+        )
+        result = scrub_event_arguments(event)
+        assert result.parameters["arguments"]["password"] == "[redacted]"
+        assert result.parameters["arguments"]["api_key"] == "[redacted]"
+        # Ordinary arguments are what make the event worth keeping.
+        assert result.parameters["arguments"]["incident_id"] == "44"
+
+    def test_nested_structures_are_walked(self):
+        event = self._event(
+            {
+                "arguments": {
+                    "nested": {"aws_secret_access_key": "AKIAsecret", "page_size": 10},
+                    "items": [{"token": "t1"}, {"name": "keep"}],
+                }
+            }
+        )
+        args = scrub_event_arguments(event).parameters["arguments"]
+        assert args["nested"]["aws_secret_access_key"] == "[redacted]"
+        assert args["nested"]["page_size"] == 10
+        assert args["items"][0]["token"] == "[redacted]"
+        assert args["items"][1]["name"] == "keep"
+
+    @pytest.mark.parametrize("parameters", [None, {}])
+    def test_missing_parameters_are_left_alone(self, parameters):
+        event = self._event(parameters)
+        assert scrub_event_arguments(event).parameters == parameters
+
+    def test_event_without_parameters_attribute_is_returned_unchanged(self):
+        event = SimpleNamespace(resource_name="list_incidents")
+        assert scrub_event_arguments(event) is event
+
+    def test_non_string_values_survive(self):
+        # Numbers, booleans and None must not be coerced to strings.
+        event = self._event({"arguments": {"page_size": 10, "all": True, "x": None}})
+        args = scrub_event_arguments(event).parameters["arguments"]
+        assert args == {"page_size": 10, "all": True, "x": None}

--- a/tests/unit/test_telemetry_scrubber.py
+++ b/tests/unit/test_telemetry_scrubber.py
@@ -524,6 +524,20 @@ class TestEventHookHostileInput:
         result = scrub_event_arguments(SimpleNamespace(parameters={"arguments": root}))
         assert "DEEPSECRET" not in str(result.parameters)
 
+    def test_the_callers_data_is_not_mutated(self):
+        # The walk builds new containers rather than editing in place. AgentCat
+        # hands the hook an event dumped from the original, and dict fields can
+        # still be shared references -- mutating one would corrupt the other.
+        # (Their own PR #51 fixed exactly this aliasing class on the SDK side.)
+        original = {"arguments": {"incident_id": "44", "password": "hunter2"}}
+        before = {"arguments": dict(original["arguments"])}
+
+        result = scrub_event_arguments(SimpleNamespace(parameters=original))
+
+        assert original == before, "hook mutated the caller's dict"
+        assert result.parameters is not original
+        assert result.parameters["arguments"]["password"] == "[redacted]"
+
     def test_ordinary_nesting_is_still_walked(self):
         event = SimpleNamespace(
             parameters={"arguments": {"a": {"b": {"c": {"password": "p", "id": "44"}}}}}

--- a/tests/unit/test_telemetry_scrubber.py
+++ b/tests/unit/test_telemetry_scrubber.py
@@ -452,3 +452,44 @@ class TestScrubEventArguments:
         event = self._event({"arguments": {"page_size": 10, "all": True, "x": None}})
         args = scrub_event_arguments(event).parameters["arguments"]
         assert args == {"page_size": 10, "all": True, "x": None}
+
+
+class TestClientIdentificationSurvives:
+    """User-agent strings must not be scrubbed.
+
+    AgentCat falls back to the user-agent header to identify which client made
+    a call, so redacting it would cost exactly the attribution this telemetry
+    exists to provide. Flagged by AgentCat during the 2.0.2 rollout.
+    """
+
+    @pytest.mark.parametrize(
+        "key",
+        ["user-agent", "user_agent", "User-Agent", "useragent", "x-client-name"],
+    )
+    def test_header_names_are_not_credentials(self, key):
+        assert is_credential_key(key) is False
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "User-Agent: Odin/1.2.0",
+            "user-agent: claude-code/2.1.4 (darwin; arm64)",
+            "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+            "user_agent=cursor-mcp/0.9",
+            "{'headers': {'user-agent': 'Odin/1.2.0', 'accept': 'application/json'}}",
+            "User-Agent: python-httpx/0.27.0",
+            "user-agent: node-fetch/1.0 (+https://github.com/bitinn/node-fetch)",
+        ],
+    )
+    def test_user_agents_pass_through_untouched(self, value):
+        assert redact_agentcat_telemetry_text(value) == value
+
+    def test_event_hook_keeps_user_agent_but_removes_credentials(self):
+        event = SimpleNamespace(
+            parameters={
+                "arguments": {"headers": {"user-agent": "Odin/1.2.0", "authorization": "Bearer x"}}
+            }
+        )
+        headers = scrub_event_arguments(event).parameters["arguments"]["headers"]
+        assert headers["user-agent"] == "Odin/1.2.0"
+        assert headers["authorization"] == "[redacted]"


### PR DESCRIPTION
Stacked on #179 — please merge that first. The diff against `main` will look larger than it is until then; the change here is 29 lines of source plus tests.

## What this does

Scrubs credentials that are passed as tool *arguments*, using AgentCat's event-level hook.

The existing hook, `redact_sensitive_information`, receives one bare string at a time. When a tool is called with `password: "hunter2"`, the string that arrives is just `hunter2` — nothing says it came from a field called `password`. Catching that from the string alone would need an entropy check, and that would also match incident IDs, UUIDs and service slugs, which is exactly the over-redaction that caused the outage #179 fixes.

`redact_event` receives the whole event, so the field name is there to read.

```
before:  {'incident_id': '44', 'password': 'hunter2', 'api_key': 'plainvalue',
          'nested': {'aws_secret_access_key': 'AKIAsecret', 'page_size': 10}}

after:   {'incident_id': '44', 'password': '[redacted]', 'api_key': '[redacted]',
          'nested': {'aws_secret_access_key': '[redacted]', 'page_size': 10}}
```

Nested dicts and lists are walked, non-string values are left alone, and `incident_id` and `page_size` survive. It reuses `is_credential_key` from #179 rather than introducing a second policy, so there is one place that decides what counts as a credential.

`response` and `error` deliberately stay with the string scrubber: they are free text with no keys to read.

## Why it is safe to merge before AgentCat cuts the tag

The hook is offered only when the installed SDK accepts it.

This matters more than it looks. `redact_event` landed after 2.0.1, and passing an unknown option to `AgentCatOptions` raises `TypeError` — which `maybe_enable_mcpcat_tracking` catches and turns into "AgentCat tracking could not be enabled; skipping". Using it unconditionally would therefore switch telemetry **off entirely** for anyone on the current release. That is a worse failure than the one we just fixed, and a silent one.

Detection reads the options dataclass fields, so the branch is inert on 2.0.1 and starts working when the image picks up the new release. No coordinated deploy.

Verified by installing both SDKs for real — 2.0.1 from PyPI, and the merge commit of agentcathq/agentcat-python-sdk#50:

| SDK | `redact_event` offered | telemetry enabled |
|---|---|---|
| 2.0.1 (released) | no | yes |
| `main` (PR #50) | yes | yes |

## Not included

No version pin bump. The Dockerfile still pins `agentcat[community]==2.0.1` because the tag does not exist yet. Once AgentCat publishes, bumping that one line is the only remaining step — the code needs no change.

## Testing

- 724 tests pass.
- Event-hook coverage: credential-named arguments removed, nested dicts and lists walked, non-string values preserved, missing or empty `parameters` handled, an event without a `parameters` attribute returned untouched.
- Feature-detection coverage: the hook is passed when the options class has the field and omitted when it does not, and telemetry stays enabled either way.
- End-to-end through the SDK's own `apply_event_redaction` and `redact_event`, confirming diagnostics survive: `client_name`, `resource_name`, `session_id` and the error message all come through intact.
- ruff, pyright, mypy and bandit clean.

## Context

Closes the remaining finding from #179, where Greptile correctly pointed out that bare argument values cannot be identified through the string hook. That was accurate and unfixable at the time. It is fixable now because of agentcathq/agentcat-python-sdk#50, which also adds `server_name` and `client_name` to `PROTECTED_FIELDS` so a customer hook can no longer destroy the identity fields — the exact failure behind the original incident.
