### PR TITLE
Split long shift ranges and stop reporting failures as zero shifts

### DIFF
--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -1554,10 +1554,27 @@ def register_oncall_tools(
             """
             response = None
             for attempt in (1, 2):
-                async with semaphore:
-                    response = await make_authenticated_request(
-                        "GET", path, params=_params_for(page_number)
+                try:
+                    async with semaphore:
+                        response = await make_authenticated_request(
+                            "GET", path, params=_params_for(page_number)
+                        )
+                except httpx.TransportError as exc:
+                    # A timeout or dropped connection arrives as a raised error,
+                    # not as a response, so it used to leave this loop before the
+                    # second attempt -- retrying only what came back meant not
+                    # retrying the failure that actually happens. Shift pages take
+                    # seconds each and a long range is dozens of them, so one lost
+                    # connection would fail the whole query.
+                    if attempt == 2:
+                        raise
+                    logger.warning(
+                        "Retrying page %d of %s after a transport error (%s)",
+                        page_number,
+                        path,
+                        type(exc).__name__,
                     )
+                    continue
                 if response is not None and response.status_code == 200:
                     return response
                 status = getattr(response, "status_code", None)

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -3,25 +3,104 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any, Protocol, cast
 
 import httpx
 from mcp.types import ToolAnnotations
 from pydantic import Field
 
+from ..exceptions import RootlyAPIError, RootlyValidationError
 from ..och_client import OnCallHealthClient
 from ..validators import validate_page_params
 
 JsonDict = dict[str, Any]
 MakeAuthenticatedRequest = Callable[..., Awaitable[Any]]
+logger = logging.getLogger(__name__)
+
 SHIFT_INCIDENT_QUERY_FIELDS = (
     "title,status,started_at,resolved_at,created_at,summary,"
     "customer_impact_summary,mitigation,severity,url"
 )
 DEFAULT_MAX_SHIFT_INCIDENT_RESULTS = 100
+
+# Ceiling on a shift query's total span. Long ranges are split into windows the
+# upstream will accept, but each window is its own request, so an unbounded
+# range would fan out indefinitely. A year of on-call is six windows.
+MAX_SHIFT_SPAN_DAYS = 366
+
+
+def _parse_iso_datetime(value: Any) -> datetime | None:
+    """Parse an ISO date or datetime to an aware UTC datetime, else ``None``.
+
+    Mirrors the transport client's parsing so a range this splits is one the
+    upstream validation would have accepted.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    candidate = value.strip()
+    try:
+        parsed = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+    except ValueError:
+        try:
+            parsed = datetime.strptime(candidate, "%Y-%m-%d")
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _shift_window_limit_days(path: str) -> int | None:
+    """Upstream ``from``/``to`` cap for a shift-listing path, else ``None``.
+
+    Read from the transport client's constants so the split here can never
+    drift from the validation that rejects an over-long range.
+    """
+    from ..transport import LIST_SHIFTS_LIMIT_DAYS, SCHEDULE_SHIFTS_LIMIT_DAYS
+
+    normalized = path.rstrip("/")
+    if not normalized.endswith("/shifts"):
+        return None
+    if normalized == "/v1/shifts":
+        return LIST_SHIFTS_LIMIT_DAYS
+    return SCHEDULE_SHIFTS_LIMIT_DAYS
+
+
+def _split_date_windows(
+    from_raw: Any, to_raw: Any, limit_days: int
+) -> list[tuple[datetime, datetime]]:
+    """Split ``from``/``to`` into consecutive windows of at most ``limit_days``.
+
+    Returns ``[]`` when the range already fits, when either bound is
+    unparseable (the upstream 422 stays authoritative for malformed input),
+    or when the range is inverted.
+    """
+    start = _parse_iso_datetime(from_raw)
+    end = _parse_iso_datetime(to_raw)
+    if start is None or end is None or end <= start:
+        return []
+    span_days = (end - start).total_seconds() / 86400
+    if span_days <= limit_days:
+        return []
+    if span_days > MAX_SHIFT_SPAN_DAYS:
+        raise RootlyValidationError(
+            f"Date range from={from_raw} to={to_raw} spans {span_days:.0f} days. "
+            f"This tool splits long ranges automatically but caps the total at "
+            f"{MAX_SHIFT_SPAN_DAYS} days, because each {limit_days}-day window is a "
+            f"separate upstream request. Narrow the range and query again."
+        )
+    windows: list[tuple[datetime, datetime]] = []
+    cursor = start
+    step = timedelta(days=limit_days)
+    while cursor < end:
+        window_end = min(cursor + step, end)
+        windows.append((cursor, window_end))
+        cursor = window_end
+    return windows
 
 
 def _truncate_text(value: Any, max_length: int = 280) -> str | None:
@@ -575,26 +654,39 @@ def register_oncall_tools(
 
             if total_pages > 1:
 
-                async def _fetch_schedule_page(page_number: int) -> list[dict]:
+                async def _fetch_schedule_page(page_number: int) -> list[dict] | None:
                     async with request_semaphore:
                         page_response = await make_authenticated_request(
                             "GET",
                             "/v1/schedules",
                             params={"page[size]": 100, "page[number]": page_number},
                         )
+                    # None, not [], so a failed page is distinguishable from a
+                    # page that genuinely held no schedules.
                     if not page_response or page_response.status_code != 200:
-                        return []
+                        return None
                     return list(page_response.json().get("data", []))
 
                 rest_pages = await asyncio.gather(
                     *(_fetch_schedule_page(p) for p in range(2, total_pages + 1)),
                     return_exceptions=True,
                 )
+                failed_schedule_pages = 0
                 for page_schedules in rest_pages:
-                    if isinstance(page_schedules, BaseException):
-                        # One transient page error shouldn't abort the whole handler.
+                    if isinstance(page_schedules, BaseException) or page_schedules is None:
+                        failed_schedule_pages += 1
                         continue
                     all_schedules.extend(page_schedules)
+                if failed_schedule_pages:
+                    # These schedules are the answer, not enrichment: dropping a
+                    # page silently omits whole schedules from the handoff, and
+                    # the caller reads the result as the full picture.
+                    return mcp_error.tool_error(
+                        f"{failed_schedule_pages} of {total_pages - 1} schedule pages "
+                        "failed to load. The handoff summary would silently omit those "
+                        "schedules, so the query is failed instead.",
+                        "execution_error",
+                    )
 
             # Build team mapping
             team_ids_set = set()
@@ -1250,6 +1342,87 @@ def register_oncall_tools(
         extra_params: dict[str, Any] | None = None,
         on_included: Callable[[list[dict[str, Any]]], None] | None = None,
         max_pages: int = 10,
+        required: bool = False,
+        report: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch a paginated JSON:API resource, splitting over-long shift ranges.
+
+        ``required`` makes a failed first page raise instead of returning an
+        empty list. Enrichment lookups leave it off -- a missing user map only
+        costs a display name -- but any fetch whose result *is* the answer must
+        set it, or an upstream failure is indistinguishable from "no results".
+
+        ``report`` is an optional dict this fills in with ``windows`` (how many
+        upstream ranges the query was split into) and ``truncated`` (whether
+        ``max_pages`` cut a window short), so callers can surface both instead
+        of quietly returning a partial answer.
+
+        The shift endpoints reject a ``from``/``to`` span beyond their cap, so a
+        longer range is split into consecutive windows, fetched through the same
+        semaphore, and merged with duplicates dropped -- a shift overlapping a
+        boundary is returned by both windows.
+        """
+        limit_days = _shift_window_limit_days(path)
+        windows: list[tuple[datetime, datetime]] = []
+        if limit_days is not None and extra_params:
+            windows = _split_date_windows(
+                extra_params.get("from"), extra_params.get("to"), limit_days
+            )
+
+        if not windows:
+            return await _fetch_page_range(
+                path,
+                semaphore,
+                extra_params=extra_params,
+                on_included=on_included,
+                max_pages=max_pages,
+                required=required,
+                report=report,
+            )
+
+        if report is not None:
+            report["windows"] = len(windows)
+
+        async def _fetch_window(start: datetime, end: datetime) -> list[dict[str, Any]]:
+            window_params = dict(extra_params or {})
+            window_params["from"] = start.isoformat().replace("+00:00", "Z")
+            window_params["to"] = end.isoformat().replace("+00:00", "Z")
+            return await _fetch_page_range(
+                path,
+                semaphore,
+                extra_params=window_params,
+                on_included=on_included,
+                max_pages=max_pages,
+                required=required,
+                report=report,
+            )
+
+        results = await asyncio.gather(*(_fetch_window(s, e) for s, e in windows))
+
+        # Drop duplicates rather than returning a shift twice: the upstream
+        # returns any shift overlapping the window, so one spanning a boundary
+        # comes back from both sides. Items without an id are kept as-is.
+        merged: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for window_items in results:
+            for item in window_items:
+                item_id = item.get("id") if isinstance(item, dict) else None
+                if isinstance(item_id, str):
+                    if item_id in seen:
+                        continue
+                    seen.add(item_id)
+                merged.append(item)
+        return merged
+
+    async def _fetch_page_range(
+        path: str,
+        semaphore: asyncio.Semaphore,
+        *,
+        extra_params: dict[str, Any] | None = None,
+        on_included: Callable[[list[dict[str, Any]]], None] | None = None,
+        max_pages: int = 10,
+        required: bool = False,
+        report: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Fetch up to ``max_pages`` of a paginated JSON:API resource.
 
@@ -1273,8 +1446,49 @@ def register_oncall_tools(
             merged["page[number]"] = page_number
             return merged
 
-        first = await make_authenticated_request("GET", path, params=_params_for(1))
+        async def _request_page(page_number: int) -> Any:
+            """Request one page, retrying once on a transient failure.
+
+            A long range is split into windows and each window paginates, so a
+            single query can be dozens of requests and any one of them failing
+            fails the whole thing. One retry absorbs a blip without letting a
+            partial answer through.
+
+            Only transient failures are retried. A 4xx is the upstream saying
+            no -- it will say no again, and retrying only doubles the load.
+            """
+            response = None
+            for attempt in (1, 2):
+                async with semaphore:
+                    response = await make_authenticated_request(
+                        "GET", path, params=_params_for(page_number)
+                    )
+                if response is not None and response.status_code == 200:
+                    return response
+                status = getattr(response, "status_code", None)
+                if status is not None and 400 <= status < 500:
+                    return response
+                if attempt == 1:
+                    logger.warning(
+                        "Retrying page %d of %s after a transient failure (status=%s)",
+                        page_number,
+                        path,
+                        status,
+                    )
+            return response
+
+        first = await _request_page(1)
         if not first or first.status_code != 200:
+            # Returning [] here reads to the caller as "no results", which is
+            # how an upstream failure got reported to users as zero shifts.
+            if required:
+                status = getattr(first, "status_code", None)
+                raise RootlyAPIError(
+                    f"Upstream request to {path} failed"
+                    + (f" with status {status}" if status else " (no response)")
+                    + ". Returning no results would be indistinguishable from an "
+                    "empty result, so the query is failed instead."
+                )
             return []
         first_data = first.json()
         items: list[dict[str, Any]] = list(first_data.get("data", []))
@@ -1293,22 +1507,37 @@ def register_oncall_tools(
         # just come back empty, harmlessly.
         meta = first_data.get("meta") or {}
         total_pages_raw = meta.get("total_pages")
-        if total_pages_raw is None:
-            total_pages = max_pages
-        else:
+        # Parsed once and shared, so paginating and reporting cannot disagree
+        # about what the upstream said. Checking the raw value's type here
+        # instead would skip reporting for a numeric string that pagination
+        # accepts, and the result would be truncated with nothing to say so.
+        reported_pages: int | None = None
+        if total_pages_raw is not None:
             try:
-                total_pages = int(total_pages_raw)
+                reported_pages = int(total_pages_raw)
             except (TypeError, ValueError):
-                total_pages = max_pages
+                reported_pages = None
+        total_pages = reported_pages if reported_pages is not None else max_pages
+        # Record the cut before clamping: past max_pages the caller is holding a
+        # partial resource and has no other way to know it.
+        if report is not None and reported_pages is not None:
+            # Every window counts toward these totals, not only the ones that
+            # were cut short: the note presents them as query-wide, so omitting
+            # a fully fetched window understates both halves. Accumulated
+            # rather than assigned because windows run concurrently. Safe
+            # without a lock -- no await between the read and the write.
+            report["available_pages"] = report.get("available_pages", 0) + reported_pages
+            report["fetched_pages"] = report.get("fetched_pages", 0) + min(
+                reported_pages, max_pages
+            )
+            if reported_pages > max_pages:
+                report["truncated"] = True
         total_pages = min(max(total_pages, 1), max_pages)
         if total_pages <= 1:
             return items
 
         async def _fetch_page(page_number: int) -> dict[str, Any] | None:
-            async with semaphore:
-                response = await make_authenticated_request(
-                    "GET", path, params=_params_for(page_number)
-                )
+            response = await _request_page(page_number)
             if not response or response.status_code != 200:
                 return None
             return cast(dict[str, Any], response.json())
@@ -1317,13 +1546,32 @@ def register_oncall_tools(
             *(_fetch_page(p) for p in range(2, total_pages + 1)),
             return_exceptions=True,
         )
+        failed_pages = 0
         for page_payload in rest:
             if isinstance(page_payload, BaseException) or page_payload is None:
-                # One transient page error shouldn't drop the whole resource.
+                # One transient page error shouldn't drop a best-effort
+                # enrichment lookup, but for a fetch whose result is the answer
+                # it means the caller would receive a short list and read it as
+                # complete -- the same failure as the first page returning
+                # empty, just further in.
+                failed_pages += 1
                 continue
             items.extend(page_payload.get("data", []))
             if on_included:
                 on_included(list(page_payload.get("included", [])))
+        if failed_pages and required:
+            raise RootlyAPIError(
+                f"{failed_pages} of {total_pages - 1} additional pages from {path} failed. "
+                "The partial result would read as complete, so the query is failed instead."
+            )
+        # No page count from the upstream means the ceiling was used as a
+        # guess. Every page coming back full is the only evidence available
+        # that more exist, and without saying so the caller reads ten pages as
+        # the whole answer.
+        if report is not None and reported_pages is None and len(items) >= max_pages * 100:
+            report["truncated"] = True
+            report["fetched_pages"] = report.get("fetched_pages", 0) + max_pages
+            report["total_unknown"] = True
         return items
 
     async def _fetch_users_and_schedules_maps() -> tuple[
@@ -1448,6 +1696,16 @@ def register_oncall_tools(
 
         Use this instead of the auto-generated listShifts when you need user filtering
         or dependable pagination on large tenants.
+
+        Answers questions about *individual* shifts: who is on call at a given
+        time, when a handoff happens, which shifts were overrides, or one
+        person's schedule (via user_ids). For questions about totals across a
+        team -- hours per responder, coverage, load -- use
+        get_oncall_schedule_summary, whose response size depends on team size
+        rather than on how long a range you asked for.
+
+        Ranges longer than the upstream cap are split into windows and merged
+        automatically, so a multi-month range is a normal request.
         """
         try:
             from datetime import datetime
@@ -1499,11 +1757,14 @@ def register_oncall_tools(
                         if isinstance(uid, str):
                             users_map[uid] = resource
 
+            fetch_report: dict[str, Any] = {}
             all_shifts = await _fetch_all_pages(
                 "/v1/shifts",
                 asyncio.Semaphore(10),
                 extra_params=params,
                 on_included=_merge_users,
+                required=True,
+                report=fetch_report,
             )
 
             # Process and filter shifts
@@ -1589,6 +1850,31 @@ def register_oncall_tools(
                     "returned_shifts": len(paginated_shifts),
                     "has_more": has_more,
                     "next_page": page_number + 1 if has_more else None,
+                    # Present only when they apply, so a normal response is
+                    # unchanged and either flag is a real signal.
+                    **(
+                        {"upstream_windows": fetch_report["windows"]}
+                        if fetch_report.get("windows")
+                        else {}
+                    ),
+                    **(
+                        {
+                            "truncated": True,
+                            "truncation_note": (
+                                "More shifts exist upstream than this query fetched "
+                                f"({fetch_report.get('fetched_pages')} of "
+                                + (
+                                    "an unreported number of"
+                                    if fetch_report.get("total_unknown")
+                                    else str(fetch_report.get("available_pages"))
+                                )
+                                + " pages). Narrow the date range, or filter by "
+                                "schedule_ids or user_ids."
+                            ),
+                        }
+                        if fetch_report.get("truncated")
+                        else {}
+                    ),
                 },
                 "shifts": paginated_shifts,
             }
@@ -1638,10 +1924,17 @@ def register_oncall_tools(
         Returns one entry per user per schedule (not raw shifts), with
         aggregated hours. Optimized for AI agent context windows.
 
-        Use this instead of listShifts when you need:
+        Use this instead of list_shifts when you need:
         - Aggregated hours per responder
         - Schedule coverage overview
         - Responder load analysis with warnings
+
+        One row per user per schedule, so the response stays the same size
+        whether the range is a week or a year. For individual shift times, or
+        for one person's schedule, use list_shifts instead.
+
+        Ranges longer than the upstream cap are split into windows and merged
+        automatically.
         """
         try:
             from collections import defaultdict
@@ -1704,6 +1997,7 @@ def register_oncall_tools(
                 asyncio.Semaphore(10),
                 extra_params=shift_params,
                 on_included=_merge_users,
+                required=True,
             )
 
             # Aggregate by schedule and user
@@ -1945,6 +2239,7 @@ def register_oncall_tools(
                 asyncio.Semaphore(10),
                 extra_params=shift_params,
                 on_included=_merge_users,
+                required=True,
             )
 
             # Group shifts by user
@@ -2169,6 +2464,7 @@ def register_oncall_tools(
                 asyncio.Semaphore(10),
                 extra_params=shift_params,
                 on_included=_merge_users,
+                required=True,
             )
 
             # Calculate load per user
@@ -2411,6 +2707,7 @@ def register_oncall_tools(
                     asyncio.Semaphore(10),
                     extra_params=shift_params,
                     on_included=_merge_users_and_schedules,
+                    required=True,
                 )
             )
 

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -177,6 +177,23 @@ def _shifts_future_horizon_note(to_raw: Any) -> str | None:
     )
 
 
+def _pages_fetched_phrase(report: dict[str, Any]) -> str:
+    """How much of the range was fetched, as "N of M pages".
+
+    The upstream does not always report ``meta.total_pages``, and when it does
+    not the page ceiling is still what stopped the fetch. Saying "of None"
+    there reads like a bug in the answer rather than an unknown total, so the
+    unknown is named. Shared by every truncation note: the three were written
+    separately and immediately drifted, with one rendering "10 of None pages".
+    """
+    total = (
+        "an unreported number of"
+        if report.get("total_unknown")
+        else str(report.get("available_pages"))
+    )
+    return f"{report.get('fetched_pages')} of {total} pages"
+
+
 def _truncate_text(value: Any, max_length: int = 280) -> str | None:
     """Keep large narrative fields compact enough for MCP clients."""
     if not value:
@@ -614,14 +631,8 @@ def register_oncall_tools(
                 fetch_meta["truncated"] = True
                 fetch_meta["truncation_note"] = (
                     "These totals cover only part of the range: more shifts exist "
-                    f"upstream than this query fetched ({fetch_report.get('fetched_pages')} of "
-                    + (
-                        "an unreported number of"
-                        if fetch_report.get("total_unknown")
-                        else str(fetch_report.get("available_pages"))
-                    )
-                    + " pages). Narrow the range, or filter by schedule_ids, "
-                    "team_ids or user_ids."
+                    f"upstream than this query fetched ({_pages_fetched_phrase(fetch_report)}). "
+                    "Narrow the range, or filter by schedule_ids, team_ids or user_ids."
                 )
             horizon_note = _shifts_future_horizon_note(end_date)
             if horizon_note:
@@ -1833,8 +1844,7 @@ def register_oncall_tools(
                 result["truncated"] = True
                 result["truncation_note"] = (
                     "More shifts exist upstream than this query fetched "
-                    f"({fetch_report.get('fetched_pages')} of "
-                    f"{fetch_report.get('available_pages')} pages). Narrow the date range."
+                    f"({_pages_fetched_phrase(fetch_report)}). Narrow the date range."
                 )
             return result
         except Exception as e:
@@ -2081,14 +2091,8 @@ def register_oncall_tools(
                             "truncated": True,
                             "truncation_note": (
                                 "More shifts exist upstream than this query fetched "
-                                f"({fetch_report.get('fetched_pages')} of "
-                                + (
-                                    "an unreported number of"
-                                    if fetch_report.get("total_unknown")
-                                    else str(fetch_report.get("available_pages"))
-                                )
-                                + " pages). Narrow the date range, or filter by "
-                                "schedule_ids or user_ids."
+                                f"({_pages_fetched_phrase(fetch_report)}). Narrow the "
+                                "date range, or filter by schedule_ids or user_ids."
                             ),
                         }
                         if fetch_report.get("truncated")

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -103,6 +103,38 @@ def _split_date_windows(
     return windows
 
 
+# How far ahead `/v1/shifts` actually has data. It serves shifts that already
+# exist as rows, which upstream generates about a month out; measured against
+# the live API, a `from` of today+31 still returns shifts and today+32 returns
+# an empty list. `/v1/schedules/{id}/shifts` derives shifts from rotations on
+# request and has no such horizon, which is why a schedule visible months ahead
+# in the UI looks empty through this endpoint.
+SHIFTS_FUTURE_HORIZON_DAYS = 31
+
+
+def _shifts_future_horizon_note(to_raw: Any) -> str | None:
+    """Note for a ``/v1/shifts`` range reaching past the generated-shift horizon.
+
+    Upstream answers those requests with an empty list rather than an error, so
+    without this the caller cannot tell "no one is on call" from "not generated
+    yet" — the count would read as fact. Returns ``None`` when the range ends
+    inside the horizon, leaving ordinary responses untouched.
+    """
+    end = _parse_iso_datetime(to_raw)
+    if end is None:
+        return None
+    horizon = datetime.now(UTC) + timedelta(days=SHIFTS_FUTURE_HORIZON_DAYS)
+    if end <= horizon:
+        return None
+    return (
+        f"This range extends past {horizon.date().isoformat()}. Beyond that date "
+        f"/v1/shifts has no generated shifts yet and returns none instead of an "
+        f"error, so counts here can understate a future period. Use "
+        f"get_schedule_shifts for later dates; it derives shifts from rotations "
+        f"and covers them."
+    )
+
+
 def _truncate_text(value: Any, max_length: int = 280) -> str | None:
     """Keep large narrative fields compact enough for MCP clients."""
     if not value:
@@ -1902,6 +1934,7 @@ def register_oncall_tools(
             end_index = start_index + page_size
             paginated_shifts = enriched_shifts[start_index:end_index]
             has_more = end_index < total_matching_shifts
+            horizon_note = _shifts_future_horizon_note(to_date)
 
             return {
                 "period": {"from": from_date, "to": to_date},
@@ -1943,6 +1976,7 @@ def register_oncall_tools(
                         if fetch_report.get("truncated")
                         else {}
                     ),
+                    **({"future_horizon_note": horizon_note} if horizon_note else {}),
                 },
                 "shifts": paginated_shifts,
             }

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -180,18 +180,20 @@ def _shifts_future_horizon_note(to_raw: Any) -> str | None:
 def _pages_fetched_phrase(report: dict[str, Any]) -> str:
     """How much of the range was fetched, as "N of M pages".
 
-    The upstream does not always report ``meta.total_pages``, and when it does
-    not the page ceiling is still what stopped the fetch. Saying "of None"
-    there reads like a bug in the answer rather than an unknown total, so the
-    unknown is named. Shared by every truncation note: the three were written
-    separately and immediately drifted, with one rendering "10 of None pages".
+    The upstream does not always report ``meta.total_pages``. Where it stayed
+    silent the total counts what was read, which is a floor rather than the
+    real figure, so the wording says so instead of presenting a guess as fact.
+    Both halves count the same windows either way: a window missing from one
+    and present in the other reads as a larger shortfall than there is.
+
+    Shared by every truncation note. The three were written separately and
+    drifted within a day, one of them rendering "10 of None pages".
     """
-    total = (
-        "an unreported number of"
-        if report.get("total_unknown")
-        else str(report.get("available_pages"))
-    )
-    return f"{report.get('fetched_pages')} of {total} pages"
+    fetched = report.get("fetched_pages")
+    total = report.get("available_pages")
+    if report.get("total_unknown"):
+        return f"{fetched} of at least {total} pages"
+    return f"{fetched} of {total} pages"
 
 
 def _truncate_text(value: Any, max_length: int = 280) -> str | None:
@@ -1623,9 +1625,12 @@ def register_oncall_tools(
         if len(items) < 100:
             # Counted even though nothing was truncated here: a window that
             # finished in one page is still a page this query read, and the
-            # note presents the figure as query-wide.
+            # note presents the figure as query-wide. A short page is also the
+            # end of this window, so one page is all there was -- both halves
+            # of the figure move together.
             if report is not None:
                 report["fetched_pages"] = report.get("fetched_pages", 0) + 1
+                report["available_pages"] = report.get("available_pages", 0) + 1
             return items
 
         # Trust meta.total_pages when provided. When the field is missing
@@ -1697,14 +1702,22 @@ def register_oncall_tools(
             # actually read. Counting it up there meant such a window added
             # nothing unless it filled the ceiling, and another window's
             # truncation then published a figure missing those pages.
-            report["fetched_pages"] = report.get("fetched_pages", 0) + (total_pages - failed_pages)
+            read_here = total_pages - failed_pages
+            report["fetched_pages"] = report.get("fetched_pages", 0) + read_here
+            if reported_pages is None:
+                # Nothing was said about how many exist, so what was read is
+                # the only floor available. Adding it keeps the two halves
+                # counting the same windows -- otherwise this window's pages
+                # appear in the fetched figure and nowhere in the total, and
+                # the note reads as a larger shortfall than there is.
+                report["available_pages"] = report.get("available_pages", 0) + read_here
+                report["total_unknown"] = True
         # No page count from the upstream means the ceiling was used as a
         # guess. Every page coming back full is the only evidence available
         # that more exist, and without saying so the caller reads ten pages as
         # the whole answer.
         if report is not None and reported_pages is None and len(items) >= max_pages * 100:
             report["truncated"] = True
-            report["total_unknown"] = True
         return items
 
     async def _fetch_users_and_schedules_maps() -> tuple[

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -1621,6 +1621,11 @@ def register_oncall_tools(
         # Don't fan out if the first page is short - matches the legacy
         # "< 100 items means we're done" termination signal.
         if len(items) < 100:
+            # Counted even though nothing was truncated here: a window that
+            # finished in one page is still a page this query read, and the
+            # note presents the figure as query-wide.
+            if report is not None:
+                report["fetched_pages"] = report.get("fetched_pages", 0) + 1
             return items
 
         # Trust meta.total_pages when provided. When the field is missing
@@ -1650,13 +1655,12 @@ def register_oncall_tools(
             # rather than assigned because windows run concurrently. Safe
             # without a lock -- no await between the read and the write.
             report["available_pages"] = report.get("available_pages", 0) + reported_pages
-            report["fetched_pages"] = report.get("fetched_pages", 0) + min(
-                reported_pages, max_pages
-            )
             if reported_pages > max_pages:
                 report["truncated"] = True
         total_pages = min(max(total_pages, 1), max_pages)
         if total_pages <= 1:
+            if report is not None:
+                report["fetched_pages"] = report.get("fetched_pages", 0) + 1
             return items
 
         async def _fetch_page(page_number: int) -> dict[str, Any] | None:
@@ -1687,13 +1691,19 @@ def register_oncall_tools(
                 f"{failed_pages} of {total_pages - 1} additional pages from {path} failed. "
                 "The partial result would read as complete, so the query is failed instead."
             )
+        if report is not None:
+            # Counted here rather than from the reported total, so a window
+            # whose total the upstream withheld still contributes what it
+            # actually read. Counting it up there meant such a window added
+            # nothing unless it filled the ceiling, and another window's
+            # truncation then published a figure missing those pages.
+            report["fetched_pages"] = report.get("fetched_pages", 0) + (total_pages - failed_pages)
         # No page count from the upstream means the ceiling was used as a
         # guess. Every page coming back full is the only evidence available
         # that more exist, and without saying so the caller reads ten pages as
         # the whole answer.
         if report is not None and reported_pages is None and len(items) >= max_pages * 100:
             report["truncated"] = True
-            report["fetched_pages"] = report.get("fetched_pages", 0) + max_pages
             report["total_unknown"] = True
         return items
 

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -11,7 +11,7 @@ from typing import Annotated, Any, Protocol, cast
 
 import httpx
 from mcp.types import ToolAnnotations
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from ..exceptions import RootlyAPIError, RootlyValidationError
 from ..och_client import OnCallHealthClient
@@ -1759,13 +1759,23 @@ def register_oncall_tools(
     )
     async def get_schedule_shifts(
         id: Annotated[str, Field(description="Schedule ID (UUID) to fetch shifts for")],
-        from_date: Annotated[
+        start_date: Annotated[
             str,
-            Field(description="Start date/time (ISO 8601, e.g. '2026-08-01T00:00:00Z')"),
+            Field(
+                description="Start date/time (ISO 8601, e.g. '2026-08-01T00:00:00Z')",
+                # The generated tool this replaces took `from`/`to`, and the
+                # other shift tool takes `from_date`/`to_date`. Accepting all of
+                # them keeps a caller working while the schema advertises the
+                # name the rest of the on-call tools use.
+                validation_alias=AliasChoices("start_date", "from_date", "from"),
+            ),
         ] = "",
-        to_date: Annotated[
+        end_date: Annotated[
             str,
-            Field(description="End date/time (ISO 8601, e.g. '2026-09-30T23:59:59Z')"),
+            Field(
+                description="End date/time (ISO 8601, e.g. '2026-09-30T23:59:59Z')",
+                validation_alias=AliasChoices("end_date", "to_date", "to"),
+            ),
         ] = "",
     ) -> dict:
         """
@@ -1783,16 +1793,16 @@ def register_oncall_tools(
         # Built before the try so the error path can always report what was
         # sent, even if the failure happens on the first statement inside.
         params: dict[str, Any] = {}
-        if from_date:
-            params["from"] = from_date
-        if to_date:
-            params["to"] = to_date
+        if start_date:
+            params["from"] = start_date
+        if end_date:
+            params["to"] = end_date
 
         # Omitting a bound is a valid "no filter" here, but a bound that is
         # present and unusable is not: upstream would ignore it and answer for a
         # different period.
         date_error = _date_argument_error(
-            {"from_date": from_date, "to_date": to_date}, required=False
+            {"start_date": start_date, "end_date": end_date}, required=False
         )
         if date_error:
             return mcp_error.tool_error(
@@ -1813,7 +1823,7 @@ def register_oncall_tools(
 
             result: dict[str, Any] = {
                 "schedule_id": id,
-                "period": {"from": from_date or None, "to": to_date or None},
+                "period": {"from": start_date or None, "to": end_date or None},
                 "total_shifts": len(shifts),
                 "shifts": shifts,
             }
@@ -1842,13 +1852,19 @@ def register_oncall_tools(
         from_date: Annotated[
             str,
             Field(
-                description="Start date/time for shift query (ISO 8601 format, e.g., '2026-02-09T00:00:00Z')"
+                description="Start date/time for shift query (ISO 8601 format, e.g., '2026-02-09T00:00:00Z')",
+                # Most on-call tools name this start_date/end_date. Accepting
+                # both means a caller that reaches for the other convention --
+                # having just called one of those tools -- is not turned away
+                # over the spelling.
+                validation_alias=AliasChoices("from_date", "start_date"),
             ),
         ],
         to_date: Annotated[
             str,
             Field(
-                description="End date/time for shift query (ISO 8601 format, e.g., '2026-02-15T23:59:59Z')"
+                description="End date/time for shift query (ISO 8601 format, e.g., '2026-02-15T23:59:59Z')",
+                validation_alias=AliasChoices("to_date", "end_date"),
             ),
         ],
         user_ids: Annotated[

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -111,6 +111,39 @@ def _split_date_windows(
 # in the UI looks empty through this endpoint.
 SHIFTS_FUTURE_HORIZON_DAYS = 31
 
+
+def _date_argument_error(dates: dict[str, Any], *, required: bool) -> str | None:
+    """Message naming the date arguments that cannot be used, else ``None``.
+
+    Upstream is not a dependable backstop for these. ``from=not-a-date`` comes
+    back 200 with an unfiltered page, and an empty bound is ignored the same
+    way, so a nonsense range is answered as though it were the one asked for --
+    only values like ``2026-13-45`` earn a 400. Rejecting them here keeps a
+    malformed request an error instead of a plausible-looking answer.
+
+    ``required`` also rejects a missing or empty bound, for callers whose whole
+    question is the range; tools where the bounds are optional filters pass
+    ``False`` so omitting them still means "no filter".
+    """
+    unusable: list[str] = []
+    for name, value in dates.items():
+        if value is None or (isinstance(value, str) and not value.strip()):
+            if required:
+                unusable.append(f"{name} is empty")
+            continue
+        if _parse_iso_datetime(value) is None:
+            unusable.append(f"{name}={value!r} is not an ISO 8601 date or datetime")
+    if not unusable:
+        return None
+    return (
+        "Cannot run this query: "
+        + "; ".join(unusable)
+        + ". Upstream ignores an unusable bound rather than rejecting it, so "
+        "continuing would return shifts for a different period than the one "
+        "asked for. Use a date like '2026-08-12' or '2026-08-12T00:00:00Z'."
+    )
+
+
 # Pages fetched per window when computing metrics. The listing tools page their
 # own output, so hitting the shared 10-page ceiling costs the tail of a list the
 # caller can page through; a metric is one number, and one computed from part of
@@ -273,6 +306,16 @@ def register_oncall_tools(
         try:
             from collections import defaultdict
             from datetime import datetime, timedelta
+
+            date_error = _date_argument_error(
+                {"start_date": start_date, "end_date": end_date}, required=True
+            )
+            if date_error:
+                return mcp_error.tool_error(
+                    f"Failed to get on-call shift metrics: {date_error}",
+                    "validation_error",
+                    details={"start_date": start_date, "end_date": end_date},
+                )
 
             # Build query parameters
             params: dict[str, Any] = {
@@ -1728,6 +1771,19 @@ def register_oncall_tools(
         if to_date:
             params["to"] = to_date
 
+        # Omitting a bound is a valid "no filter" here, but a bound that is
+        # present and unusable is not: upstream would ignore it and answer for a
+        # different period.
+        date_error = _date_argument_error(
+            {"from_date": from_date, "to_date": to_date}, required=False
+        )
+        if date_error:
+            return mcp_error.tool_error(
+                f"Failed to get schedule shifts: {date_error}",
+                "validation_error",
+                details={"schedule_id": id, "params": params},
+            )
+
         try:
             fetch_report: dict[str, Any] = {}
             shifts = await _fetch_all_pages(
@@ -1836,6 +1892,15 @@ def register_oncall_tools(
                     "page_number must be >= 1 for list_shifts",
                     "validation_error",
                     details={"page_number": page_number},
+                )
+            date_error = _date_argument_error(
+                {"from_date": from_date, "to_date": to_date}, required=True
+            )
+            if date_error:
+                return mcp_error.tool_error(
+                    f"Failed to list shifts: {date_error}",
+                    "validation_error",
+                    details={"from_date": from_date, "to_date": to_date},
                 )
             # Build query parameters (page[size] / page[number] handled by helper)
             params: dict[str, Any] = {

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -1645,6 +1645,74 @@ def register_oncall_tools(
     @mcp.tool(
         annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     )
+    async def get_schedule_shifts(
+        id: Annotated[str, Field(description="Schedule ID (UUID) to fetch shifts for")],
+        from_date: Annotated[
+            str,
+            Field(description="Start date/time (ISO 8601, e.g. '2026-08-01T00:00:00Z')"),
+        ] = "",
+        to_date: Annotated[
+            str,
+            Field(description="End date/time (ISO 8601, e.g. '2026-09-30T23:59:59Z')"),
+        ] = "",
+    ) -> dict:
+        """
+        List shifts for one schedule over a date range.
+
+        Replaces the generated getScheduleShifts, which passed the range
+        straight through and failed with `Datetime range exceeds 1 month` on
+        anything longer than the upstream accepts. Ranges longer than that are
+        split into windows and merged here, so a two-month question is a normal
+        request.
+
+        Use list_shifts instead when the question spans schedules or filters by
+        user.
+        """
+        # Built before the try so the error path can always report what was
+        # sent, even if the failure happens on the first statement inside.
+        params: dict[str, Any] = {}
+        if from_date:
+            params["from"] = from_date
+        if to_date:
+            params["to"] = to_date
+
+        try:
+            fetch_report: dict[str, Any] = {}
+            shifts = await _fetch_all_pages(
+                f"/v1/schedules/{id}/shifts",
+                asyncio.Semaphore(10),
+                extra_params=params,
+                required=True,
+                report=fetch_report,
+            )
+
+            result: dict[str, Any] = {
+                "schedule_id": id,
+                "period": {"from": from_date or None, "to": to_date or None},
+                "total_shifts": len(shifts),
+                "shifts": shifts,
+            }
+            if fetch_report.get("windows"):
+                result["upstream_windows"] = fetch_report["windows"]
+            if fetch_report.get("truncated"):
+                result["truncated"] = True
+                result["truncation_note"] = (
+                    "More shifts exist upstream than this query fetched "
+                    f"({fetch_report.get('fetched_pages')} of "
+                    f"{fetch_report.get('available_pages')} pages). Narrow the date range."
+                )
+            return result
+        except Exception as e:
+            error_type, error_message = mcp_error.categorize_error(e)
+            return mcp_error.tool_error(
+                f"Failed to get schedule shifts: {error_message}",
+                error_type,
+                details={"schedule_id": id, "params": params},
+            )
+
+    @mcp.tool(
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
     async def list_shifts(
         from_date: Annotated[
             str,

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -111,6 +111,15 @@ def _split_date_windows(
 # in the UI looks empty through this endpoint.
 SHIFTS_FUTURE_HORIZON_DAYS = 31
 
+# Pages fetched per window when computing metrics. The listing tools page their
+# own output, so hitting the shared 10-page ceiling costs the tail of a list the
+# caller can page through; a metric is one number, and one computed from part of
+# the range is wrong in a way that reads as a quiet month. A single 60-day window
+# in a 17-schedule workspace already returns about a thousand shifts, so the
+# shared default would cut an ordinary monthly report. Truncation is still
+# reported when even this is not enough.
+METRICS_MAX_PAGES_PER_WINDOW = 20
+
 
 def _shifts_future_horizon_note(to_raw: Any) -> str | None:
     """Note for a ``/v1/shifts`` range reaching past the generated-shift horizon.
@@ -323,41 +332,28 @@ def register_oncall_tools(
             # Include relationships for richer data
             params["include"] = "user,shift_override,on_call_role,schedule_rotation"
 
-            # Query shifts
-            try:
-                shifts_response = await make_authenticated_request(
-                    "GET", "/v1/shifts", params=params
-                )
+            # Query shifts through the shared helper, which splits a range longer
+            # than the endpoint accepts into windows and paginates each one. The
+            # previous single request asked for the whole span at once, so a
+            # report over more than the cap was refused outright rather than
+            # assembled. `required` keeps an upstream failure an error: a metric
+            # quietly computed from the pages that did arrive is indistinguishable
+            # from a genuinely quiet period.
+            fetch_report: dict[str, Any] = {}
+            included: list[dict[str, Any]] = []
 
-                if shifts_response is None:
-                    return mcp_error.tool_error(
-                        "Failed to get shifts: API request returned None", "execution_error"
-                    )
+            def _collect_included(page_included: list[dict[str, Any]]) -> None:
+                included.extend(page_included)
 
-                shifts_response.raise_for_status()
-                shifts_data = shifts_response.json()
-
-                if shifts_data is None:
-                    return mcp_error.tool_error(
-                        "Failed to get shifts: API returned null/empty response",
-                        "execution_error",
-                        details={"status": shifts_response.status_code},
-                    )
-
-                shifts = shifts_data.get("data", [])
-                included = shifts_data.get("included", [])
-            except AttributeError as e:
-                return mcp_error.tool_error(
-                    f"Failed to get shifts: Response object error - {str(e)}",
-                    "execution_error",
-                    details={"params": params},
-                )
-            except Exception as e:
-                return mcp_error.tool_error(
-                    f"Failed to get shifts: {str(e)}",
-                    "execution_error",
-                    details={"params": params, "error_type": type(e).__name__},
-                )
+            shifts = await _fetch_all_pages(
+                "/v1/shifts",
+                asyncio.Semaphore(10),
+                extra_params=params,
+                on_included=_collect_included,
+                max_pages=METRICS_MAX_PAGES_PER_WINDOW,
+                required=True,
+                report=fetch_report,
+            )
 
             # Build lookup maps for included resources
             users_map = {}
@@ -565,6 +561,29 @@ def register_oncall_tools(
             # Sort by shift count descending
             results.sort(key=lambda x: x["shift_count"], reverse=True)
 
+            # Anything that makes these numbers cover less than the range asked
+            # for. Present only when it applies, so a plain report is unchanged
+            # and any of these keys is a real signal that the totals are partial.
+            fetch_meta: dict[str, Any] = {}
+            if fetch_report.get("windows"):
+                fetch_meta["upstream_windows"] = fetch_report["windows"]
+            if fetch_report.get("truncated"):
+                fetch_meta["truncated"] = True
+                fetch_meta["truncation_note"] = (
+                    "These totals cover only part of the range: more shifts exist "
+                    f"upstream than this query fetched ({fetch_report.get('fetched_pages')} of "
+                    + (
+                        "an unreported number of"
+                        if fetch_report.get("total_unknown")
+                        else str(fetch_report.get("available_pages"))
+                    )
+                    + " pages). Narrow the range, or filter by schedule_ids, "
+                    "team_ids or user_ids."
+                )
+            horizon_note = _shifts_future_horizon_note(end_date)
+            if horizon_note:
+                fetch_meta["future_horizon_note"] = horizon_note
+
             return {
                 "period": {"start_date": start_date, "end_date": end_date},
                 "total_shifts": len(shifts),
@@ -576,6 +595,7 @@ def register_oncall_tools(
                     "total_override_shifts": sum(m["override_shifts"] for m in results),
                     "unique_people": len(results) if group_by == "user" else None,
                 },
+                **({"meta": fetch_meta} if fetch_meta else {}),
             }
 
         except Exception as e:

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -763,8 +763,15 @@ def strip_heavy_alert_data(data: dict[str, Any]) -> dict[str, Any]:
 # Date-range caps the Rootly shift endpoints enforce upstream (422 "Datetime
 # range exceeds N month(s)"). Public so the shift tools can split long ranges
 # against the same numbers this client validates against.
-LIST_SHIFTS_LIMIT_DAYS = 62
-SCHEDULE_SHIFTS_LIMIT_DAYS = 31
+#
+# Despite the "month" wording, upstream compares a fixed day count, and these
+# are the largest spans it accepts: measured against the live API from five
+# start dates (including Feb and month-end), 30/60 pass and 31/61 return 422
+# regardless of how long the calendar months involved actually are. A window
+# built at 31 or 62 days is rejected outright, so these bounds are inclusive
+# and a split must not exceed them.
+LIST_SHIFTS_LIMIT_DAYS = 60
+SCHEDULE_SHIFTS_LIMIT_DAYS = 30
 
 
 class AuthenticatedHTTPXClient:
@@ -838,8 +845,8 @@ class AuthenticatedHTTPXClient:
     # exceeds these limits; pre-flighting the check here turns a confusing
     # upstream error into an actionable client-side validation error.
     #
-    # `/v1/shifts`         → listShifts: 2 months cap
-    # `/v1/schedules/{id}/shifts` → getScheduleShifts: 1 month cap
+    # `/v1/shifts`                → listShifts: 60 days ("2 months")
+    # `/v1/schedules/{id}/shifts`  → getScheduleShifts: 30 days ("1 month")
     _LIST_SHIFTS_LIMIT_DAYS = LIST_SHIFTS_LIMIT_DAYS
     _SCHEDULE_SHIFTS_LIMIT_DAYS = SCHEDULE_SHIFTS_LIMIT_DAYS
 

--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -760,6 +760,13 @@ def strip_heavy_alert_data(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
+# Date-range caps the Rootly shift endpoints enforce upstream (422 "Datetime
+# range exceeds N month(s)"). Public so the shift tools can split long ranges
+# against the same numbers this client validates against.
+LIST_SHIFTS_LIMIT_DAYS = 62
+SCHEDULE_SHIFTS_LIMIT_DAYS = 31
+
+
 class AuthenticatedHTTPXClient:
     """An HTTPX client wrapper that handles Rootly API authentication and parameter transformation."""
 
@@ -833,8 +840,8 @@ class AuthenticatedHTTPXClient:
     #
     # `/v1/shifts`         → listShifts: 2 months cap
     # `/v1/schedules/{id}/shifts` → getScheduleShifts: 1 month cap
-    _LIST_SHIFTS_LIMIT_DAYS = 62
-    _SCHEDULE_SHIFTS_LIMIT_DAYS = 31
+    _LIST_SHIFTS_LIMIT_DAYS = LIST_SHIFTS_LIMIT_DAYS
+    _SCHEDULE_SHIFTS_LIMIT_DAYS = SCHEDULE_SHIFTS_LIMIT_DAYS
 
     @staticmethod
     def _parse_iso_date(value: Any) -> datetime | None:

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -1233,3 +1233,49 @@ class TestTruncationNoteWordsUnknownTotals:
         assert (
             _pages_fetched_phrase({"fetched_pages": 10, "available_pages": 50}) == "10 of 50 pages"
         )
+
+
+class TestEveryWindowCountsTowardTheTotals:
+    """The truncation note presents query-wide figures.
+
+    Pages were counted from the reported total, so a window whose total the
+    upstream withheld -- or one that finished in a single short page --
+    contributed nothing. Another window's truncation then published a count
+    that omitted pages this query had actually read.
+    """
+
+    @staticmethod
+    def _mixed_responder():
+        """One window ends in a short page; the rest report 50 pages and truncate."""
+
+        async def responder(method, path, params=None, **kwargs):
+            if path.endswith("/shifts"):
+                if str((params or {}).get("from", "")).startswith("2026-01"):
+                    return _ok({"data": [_shift("S1")], "meta": {}})
+                return _ok({"data": _full_page(), "meta": {"total_pages": 50}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        return responder
+
+    @pytest.mark.asyncio
+    async def test_a_short_window_still_counts(self):
+        tools = _build_tools(self._mixed_responder())
+        result = await tools["list_shifts"](from_date="2026-01-01", to_date="2026-06-30")
+
+        note = result["meta"]["truncation_note"]
+        # 1 page from the short window, then the ceiling from each of the
+        # other two. Counting only the truncated windows would say 20.
+        assert "21 of 100 pages" in note
+
+    @pytest.mark.asyncio
+    async def test_an_untruncated_query_still_reports_no_truncation(self):
+        # The counter runs on every window, so it must not imply truncation
+        # where none happened.
+        responder, _ = _responder(
+            lambda _p: _ok({"data": [_shift("S1")], "meta": {"total_pages": 1}})
+        )
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](from_date="2026-08-01", to_date="2026-08-20")
+
+        assert "truncated" not in result["meta"]
+        assert "truncation_note" not in result["meta"]

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -28,6 +28,7 @@ from test_oncall_handoff import FakeMCP, FakeMCPError  # noqa: E402
 from rootly_mcp_server.exceptions import RootlyValidationError  # noqa: E402
 from rootly_mcp_server.tools.oncall import (  # noqa: E402
     MAX_SHIFT_SPAN_DAYS,
+    METRICS_MAX_PAGES_PER_WINDOW,
     SHIFTS_FUTURE_HORIZON_DAYS,
     _parse_iso_datetime,
     _shift_window_limit_days,
@@ -846,3 +847,100 @@ class TestTransientFailureRetry:
 
         assert attempts["n"] == 2
         assert result["error"] is True
+
+
+class TestMetricsChunking:
+    """`get_oncall_shift_metrics` asked for the whole span in one request, so a
+    report longer than the cap was refused instead of assembled."""
+
+    @pytest.mark.asyncio
+    async def test_a_long_range_is_split_into_windows(self):
+        responder, recorded = _responder(
+            lambda _p: _ok({"data": [_shift("S1")], "meta": {"total_pages": 1}})
+        )
+        tools = _build_tools(responder)
+        result = await tools["get_oncall_shift_metrics"](
+            start_date="2026-01-01T00:00:00Z",
+            end_date="2026-08-01T00:00:00Z",
+            group_by="none",
+        )
+
+        assert not result.get("error")
+        spans = [(p.get("from"), p.get("to")) for p in recorded]
+        assert len(spans) > 1, "a 212-day report must be split, not sent as one range"
+        assert result["meta"]["upstream_windows"] == len(spans)
+
+    @pytest.mark.asyncio
+    async def test_windows_stay_within_the_cap(self):
+        responder, recorded = _responder(lambda _p: _ok({"data": [], "meta": {"total_pages": 1}}))
+        tools = _build_tools(responder)
+        await tools["get_oncall_shift_metrics"](
+            start_date="2026-01-01T00:00:00Z", end_date="2026-12-01T00:00:00Z"
+        )
+
+        for params in recorded:
+            start = _parse_iso_datetime(params.get("from"))
+            end = _parse_iso_datetime(params.get("to"))
+            assert (end - start).total_seconds() / 86400 <= LIST_SHIFTS_LIMIT_DAYS
+
+    @pytest.mark.asyncio
+    async def test_a_shift_on_a_window_boundary_is_counted_once(self):
+        # Both adjoining windows return a shift that overlaps the boundary, so
+        # without dedup the same on-call time is billed to someone twice.
+        responder, _ = _responder(
+            lambda _p: _ok({"data": [_shift("DUPE")], "meta": {"total_pages": 1}})
+        )
+        tools = _build_tools(responder)
+        result = await tools["get_oncall_shift_metrics"](
+            start_date="2026-01-01T00:00:00Z",
+            end_date="2026-08-01T00:00:00Z",
+            group_by="none",
+        )
+
+        assert result["total_shifts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_an_upstream_failure_does_not_become_a_quiet_month(self):
+        # The numbers are the answer here, so a failed page has to surface as an
+        # error rather than shrink the totals.
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                return _status(500)
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["get_oncall_shift_metrics"](
+            start_date="2026-07-01T00:00:00Z", end_date="2026-07-20T00:00:00Z"
+        )
+
+        assert result["error"] is True
+
+    @pytest.mark.asyncio
+    async def test_hitting_the_page_ceiling_is_reported(self):
+        responder, _ = _responder(
+            lambda _p: _ok({"data": _full_page(), "meta": {"total_pages": 500}})
+        )
+        tools = _build_tools(responder)
+        result = await tools["get_oncall_shift_metrics"](
+            start_date="2026-07-01T00:00:00Z", end_date="2026-07-20T00:00:00Z"
+        )
+
+        assert result["meta"]["truncated"] is True
+        # Totals that cover part of the range must say so, or they read as fact.
+        assert "only part of the range" in result["meta"]["truncation_note"]
+        assert f"{METRICS_MAX_PAGES_PER_WINDOW} of 500 pages" in result["meta"]["truncation_note"]
+
+    @pytest.mark.asyncio
+    async def test_a_report_inside_the_cap_is_sent_as_one_request(self):
+        responder, recorded = _responder(
+            lambda _p: _ok({"data": [_shift("S1")], "meta": {"total_pages": 1}})
+        )
+        tools = _build_tools(responder)
+        result = await tools["get_oncall_shift_metrics"](
+            start_date="2026-07-01T00:00:00Z", end_date="2026-07-20T00:00:00Z"
+        )
+
+        assert len(recorded) == 1
+        # No split happened, so nothing about windows or truncation applies and
+        # an ordinary report carries no meta at all.
+        assert "meta" not in result

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -30,6 +30,7 @@ from rootly_mcp_server.tools.oncall import (  # noqa: E402
     MAX_SHIFT_SPAN_DAYS,
     METRICS_MAX_PAGES_PER_WINDOW,
     SHIFTS_FUTURE_HORIZON_DAYS,
+    _date_argument_error,
     _parse_iso_datetime,
     _shift_window_limit_days,
     _shifts_future_horizon_note,
@@ -944,3 +945,79 @@ class TestMetricsChunking:
         # No split happened, so nothing about windows or truncation applies and
         # an ordinary report carries no meta at all.
         assert "meta" not in result
+
+
+class TestUnusableDatesAreRejected:
+    """Upstream ignores an unusable bound instead of refusing it.
+
+    `from=not-a-date` returns 200 with an unfiltered page and an empty bound
+    behaves the same, so a nonsense range came back as a confident answer for a
+    period nobody asked about. Only values like `2026-13-45` earn a 400.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        ["", "   ", None, "not-a-date", "08/12/2026", "yesterday", "2026-08-12T99:99:99Z"],
+    )
+    def test_unusable_bounds_are_named(self, value):
+        message = _date_argument_error({"from_date": value}, required=True)
+        assert message is not None
+        assert "from_date" in message
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "2026-08-12",
+            "2026-08-12T00:00:00Z",
+            "2026-08-12T00:00:00-07:00",
+            "2026-08-12T00:00:00.123456Z",
+        ],
+    )
+    def test_usable_bounds_pass(self, value):
+        assert _date_argument_error({"from_date": value}, required=True) is None
+
+    def test_an_omitted_optional_bound_is_not_an_error(self):
+        # `get_schedule_shifts` treats a missing bound as "no filter".
+        assert _date_argument_error({"from_date": "", "to_date": ""}, required=False) is None
+
+    def test_a_present_but_unusable_optional_bound_is_still_an_error(self):
+        assert _date_argument_error({"to_date": "garbage"}, required=False) is not None
+
+    @pytest.mark.asyncio
+    async def test_list_shifts_rejects_before_calling_upstream(self):
+        responder, recorded = _responder()
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](from_date="not-a-date", to_date="2026-08-01")
+
+        assert result["error"] is True
+        assert result["error_type"] == "validation_error"
+        # The point is to spend no upstream request on a query whose answer
+        # could not be trusted anyway.
+        assert recorded == []
+
+    @pytest.mark.asyncio
+    async def test_schedule_shifts_rejects_an_unusable_bound(self):
+        responder, recorded = _responder()
+        tools = _build_tools(responder)
+        result = await tools["get_schedule_shifts"](id="sched-1", from_date="whenever")
+
+        assert result["error"] is True
+        assert recorded == []
+
+    @pytest.mark.asyncio
+    async def test_schedule_shifts_without_bounds_still_queries(self):
+        responder, recorded = _responder()
+        tools = _build_tools(responder)
+        result = await tools["get_schedule_shifts"](id="sched-1")
+
+        assert not result.get("error")
+        assert len(recorded) == 1
+
+    @pytest.mark.asyncio
+    async def test_metrics_rejects_an_unusable_bound(self):
+        responder, recorded = _responder()
+        tools = _build_tools(responder)
+        result = await tools["get_oncall_shift_metrics"](start_date="", end_date="2026-08-01")
+
+        assert result["error"] is True
+        assert recorded == []

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -630,6 +630,91 @@ class TestPaginationMetadataTypes:
         assert "truncated" not in result["meta"]
 
 
+class TestCuratedScheduleShifts:
+    """The generated getScheduleShifts passed long ranges straight through and
+    failed with `Datetime range exceeds 1 month`; this is the top shift error
+    in production. The curated tool splits instead."""
+
+    @pytest.mark.asyncio
+    async def test_a_sixty_day_range_is_split_against_the_one_month_cap(self):
+        responder, seen = _responder(
+            lambda _p: _ok({"data": [_shift()], "meta": {"total_pages": 1}})
+        )
+        tools = _build_tools(responder)
+        # The exact range seen failing upstream.
+        result = await tools["get_schedule_shifts"](
+            id="f1dd57bb-2ba2-49cd-be00-64961b796b9e",
+            from_date="2026-07-30",
+            to_date="2026-09-28",
+        )
+
+        assert not result.get("error"), result
+        assert len(seen) == 2
+        assert result["upstream_windows"] == 2
+        # Consecutive, covering the requested range end to end.
+        assert seen[0]["from"].startswith("2026-07-30")
+        assert seen[0]["to"] == seen[1]["from"]
+        assert seen[1]["to"].startswith("2026-09-28")
+
+    @pytest.mark.asyncio
+    async def test_each_window_stays_within_the_schedule_cap(self):
+        responder, seen = _responder(
+            lambda _p: _ok({"data": [_shift()], "meta": {"total_pages": 1}})
+        )
+        tools = _build_tools(responder)
+        await tools["get_schedule_shifts"](id="s1", from_date="2026-01-01", to_date="2026-06-30")
+
+        assert seen, "expected the range to be split into windows"
+        for window in seen:
+            start = _parse_iso_datetime(window["from"])
+            end = _parse_iso_datetime(window["to"])
+            # Unparseable bounds would mean the split emitted something the
+            # upstream could not read.
+            assert start is not None and end is not None
+            assert (end - start).total_seconds() / 86400 <= SCHEDULE_SHIFTS_LIMIT_DAYS
+
+    @pytest.mark.asyncio
+    async def test_a_short_range_is_a_single_request(self):
+        responder, seen = _responder(
+            lambda _p: _ok({"data": [_shift()], "meta": {"total_pages": 1}})
+        )
+        tools = _build_tools(responder)
+        result = await tools["get_schedule_shifts"](
+            id="s1", from_date="2026-08-01", to_date="2026-08-20"
+        )
+
+        assert len(seen) == 1
+        assert "upstream_windows" not in result
+
+    @pytest.mark.asyncio
+    async def test_an_upstream_failure_is_an_error_not_zero_shifts(self):
+        async def responder(method, path, params=None, **kwargs):
+            if path.endswith("/shifts"):
+                return _status(500)
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["get_schedule_shifts"](
+            id="s1", from_date="2026-08-01", to_date="2026-08-20"
+        )
+
+        assert result["error"] is True
+        assert "total_shifts" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_date_range_still_works(self):
+        # Both bounds are optional on the generated tool; omitting them must
+        # not attempt a split.
+        async def responder(method, path, params=None, **kwargs):
+            return _ok({"data": [{"id": "S1", "attributes": {}}], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["get_schedule_shifts"](id="s1")
+
+        assert not result.get("error"), result
+        assert result["total_shifts"] == 1
+
+
 class TestTransientFailureRetry:
     """A split year is up to sixty requests, and any one failing fails the
     query. One retry absorbs a blip without letting partial data through."""

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -883,6 +883,8 @@ class TestMetricsChunking:
         for params in recorded:
             start = _parse_iso_datetime(params.get("from"))
             end = _parse_iso_datetime(params.get("to"))
+            # Unparseable bounds would make the span check below vacuous.
+            assert start is not None and end is not None
             assert (end - start).total_seconds() / 86400 <= LIST_SHIFTS_LIMIT_DAYS
 
     @pytest.mark.asyncio

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -1,0 +1,725 @@
+"""Tests for shift date-range splitting and upstream-failure reporting.
+
+Two customer-reported defects drive these:
+
+- A 60-day shift query reported "0 shifts" while 30- and 45-day queries returned
+  data. Any non-200 from the first page was returned as an empty list, so an
+  upstream failure was indistinguishable from an empty result.
+- Schedules visible in the Rootly UI into 2027 appeared unreachable. The
+  upstream caps a shift query's `from`/`to` span, so a longer range was rejected
+  outright instead of being split into windows the API accepts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from test_oncall_handoff import FakeMCP, FakeMCPError  # noqa: E402
+
+from rootly_mcp_server.exceptions import RootlyValidationError  # noqa: E402
+from rootly_mcp_server.tools.oncall import (  # noqa: E402
+    MAX_SHIFT_SPAN_DAYS,
+    _parse_iso_datetime,
+    _shift_window_limit_days,
+    _split_date_windows,
+    register_oncall_tools,
+)
+from rootly_mcp_server.transport import (  # noqa: E402
+    LIST_SHIFTS_LIMIT_DAYS,
+    SCHEDULE_SHIFTS_LIMIT_DAYS,
+)
+
+
+def _ok(payload: dict[str, Any]) -> Mock:
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = payload
+    return response
+
+
+def _status(code: int) -> Mock:
+    response = Mock()
+    response.status_code = code
+    response.json.return_value = {}
+    return response
+
+
+def _build_tools(responder) -> dict[str, Any]:
+    mcp = FakeMCP()
+    register_oncall_tools(
+        mcp=mcp,
+        make_authenticated_request=AsyncMock(side_effect=responder),
+        mcp_error=FakeMCPError(),
+    )
+    return mcp.tools
+
+
+def _shift(shift_id: str = "S1", *, starts: str = "2026-08-02T00:00:00Z") -> dict[str, Any]:
+    return {
+        "id": shift_id,
+        "attributes": {
+            "starts_at": starts,
+            "ends_at": "2026-08-03T00:00:00Z",
+            "schedule_id": "s1",
+        },
+        "relationships": {"user": {"data": {"id": "u1"}}},
+    }
+
+
+def _full_page() -> list[dict[str, Any]]:
+    """A page at the 100-item size, which is what makes the fetcher fan out."""
+    return [_shift(f"S{i}") for i in range(100)]
+
+
+_USER = {"id": "u1", "type": "users", "attributes": {"full_name": "A", "email": "a@x"}}
+
+
+def _responder(on_shifts=None, *, users_status: int = 200):
+    """A request stub plus the list of shift params it saw.
+
+    ``on_shifts`` receives the request params and returns the response for a
+    shift path; omit it for an empty successful page. Lookup paths answer
+    successfully so a test only has to describe the part it cares about.
+    """
+    recorded: list[dict[str, Any]] = []
+
+    async def responder(method, path, params=None, **kwargs):
+        request_params = dict(params or {})
+        if path.endswith("/shifts"):
+            recorded.append(request_params)
+            if on_shifts is not None:
+                return on_shifts(request_params)
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+        if path == "/v1/users":
+            if users_status != 200:
+                return _status(users_status)
+            return _ok({"data": [_USER], "meta": {"total_pages": 1}})
+        return _ok({"data": [], "meta": {"total_pages": 1}})
+
+    return responder, recorded
+
+
+class TestWindowLimits:
+    """The split must use the same caps the transport validates against."""
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("/v1/shifts", LIST_SHIFTS_LIMIT_DAYS),
+            ("/v1/shifts/", LIST_SHIFTS_LIMIT_DAYS),
+            ("/v1/schedules/abc/shifts", SCHEDULE_SHIFTS_LIMIT_DAYS),
+        ],
+    )
+    def test_shift_paths_report_their_cap(self, path, expected):
+        assert _shift_window_limit_days(path) == expected
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/v1/incidents",
+            # Lookalikes that are not shift-listing endpoints. The transport
+            # guard excludes these too; the split must agree with it.
+            "/v1/override_shifts/1",
+            "/v1/schedules/x/override_shifts",
+        ],
+    )
+    def test_non_shift_paths_are_not_split(self, path):
+        assert _shift_window_limit_days(path) is None
+
+
+class TestSplitDateWindows:
+    def test_range_within_the_cap_is_not_split(self):
+        assert _split_date_windows("2026-08-11", "2026-10-01", 62) == []
+
+    @pytest.mark.parametrize(
+        ("start", "end", "limit", "expected_windows"),
+        [
+            ("2026-11-01", "2027-03-01", 62, 2),
+            ("2026-01-01", "2026-12-31", 62, 6),
+            ("2026-11-01", "2027-03-01", 31, 4),
+        ],
+    )
+    def test_long_ranges_split_into_windows(self, start, end, limit, expected_windows):
+        windows = _split_date_windows(start, end, limit)
+        assert len(windows) == expected_windows
+
+    def test_windows_are_contiguous_and_cover_the_whole_range(self):
+        windows = _split_date_windows("2026-11-01", "2027-03-01", 62)
+        assert windows[0][0] == _parse_iso_datetime("2026-11-01")
+        assert windows[-1][1] == _parse_iso_datetime("2027-03-01")
+        for earlier, later in zip(windows, windows[1:], strict=False):
+            # No gap (a missing day loses shifts) and no overlap beyond the
+            # boundary itself (which dedup handles).
+            assert earlier[1] == later[0]
+
+    def test_no_window_exceeds_the_cap(self):
+        for limit in (LIST_SHIFTS_LIMIT_DAYS, SCHEDULE_SHIFTS_LIMIT_DAYS):
+            windows = _split_date_windows("2026-01-01", "2026-12-31", limit)
+            for start, end in windows:
+                assert (end - start).total_seconds() / 86400 <= limit
+
+    @pytest.mark.parametrize(
+        ("start", "end"),
+        [
+            ("2026-03-01", "2026-03-01"),  # zero span
+            ("2027-01-01", "2026-01-01"),  # inverted
+            ("garbage", "2026-01-01"),  # unparseable start
+            ("2026-01-01", "garbage"),  # unparseable end
+        ],
+    )
+    def test_degenerate_ranges_are_left_to_upstream(self, start, end):
+        # Returning [] means "don't split" -- the upstream keeps ownership of
+        # rejecting nonsense with its own error.
+        assert _split_date_windows(start, end, 62) == []
+
+    def test_span_beyond_the_ceiling_is_refused(self):
+        with pytest.raises(RootlyValidationError) as excinfo:
+            _split_date_windows("2026-01-01", "2028-01-01", 62)
+        assert str(MAX_SHIFT_SPAN_DAYS) in str(excinfo.value)
+
+
+class TestListShiftsSplitsLongRanges:
+    @staticmethod
+    async def _empty(method, path, params=None, **kwargs):
+        return _ok({"data": [], "meta": {"total_pages": 1}})
+
+    @pytest.mark.asyncio
+    async def test_long_range_issues_one_request_per_window(self):
+        seen: list[dict[str, Any]] = []
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                seen.append(dict(params or {}))
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-11-01T00:00:00Z", to_date="2027-03-01T00:00:00Z"
+        )
+
+        assert not result.get("error"), result
+        assert len(seen) == 2
+        assert result["meta"]["upstream_windows"] == 2
+        # Consecutive windows: the second starts where the first ended.
+        assert seen[0]["to"] == seen[1]["from"]
+
+    @pytest.mark.asyncio
+    async def test_short_range_is_a_single_request_with_no_window_metadata(self):
+        seen: list[dict[str, Any]] = []
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                seen.append(dict(params or {}))
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert len(seen) == 1
+        assert "upstream_windows" not in result["meta"]
+
+    @pytest.mark.asyncio
+    async def test_a_shift_spanning_a_window_boundary_is_returned_once(self):
+        # The upstream returns any shift overlapping the window, so one that
+        # straddles a boundary comes back from both sides.
+        shift = {
+            "id": "SHIFT-BOUNDARY",
+            "attributes": {
+                "starts_at": "2027-01-01T00:00:00Z",
+                "ends_at": "2027-01-03T00:00:00Z",
+                "schedule_id": "s1",
+            },
+            "relationships": {"user": {"data": {"id": "u1"}}},
+        }
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                return _ok({"data": [shift], "meta": {"total_pages": 1}})
+            if path == "/v1/users":
+                return _ok(
+                    {
+                        "data": [
+                            {
+                                "id": "u1",
+                                "type": "users",
+                                "attributes": {"full_name": "A", "email": "a@x"},
+                            }
+                        ],
+                        "meta": {"total_pages": 1},
+                    }
+                )
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-11-01T00:00:00Z", to_date="2027-03-01T00:00:00Z"
+        )
+
+        assert result["meta"]["upstream_windows"] == 2
+        assert result["total_shifts"] == 1
+        assert [s["shift_id"] for s in result["shifts"]] == ["SHIFT-BOUNDARY"]
+
+    @pytest.mark.asyncio
+    async def test_span_beyond_the_ceiling_is_reported_as_an_error(self):
+        tools = _build_tools(self._empty)
+        result = await tools["list_shifts"](
+            from_date="2026-01-01T00:00:00Z", to_date="2028-01-01T00:00:00Z"
+        )
+        assert result["error"] is True
+
+
+class TestUpstreamFailureIsNotReportedAsEmpty:
+    """The 0-shifts defect: a failed fetch must not look like an empty result."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [400, 403, 500, 502])
+    async def test_shift_fetch_failure_returns_an_error(self, status):
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                return _status(status)
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert result["error"] is True
+        assert "total_shifts" not in result
+        assert str(status) in str(result.get("message", ""))
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_empty_result_is_still_reported_as_zero(self):
+        # The fix must not turn "no shifts scheduled" into an error.
+        async def responder(method, path, params=None, **kwargs):
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert not result.get("error")
+        assert result["total_shifts"] == 0
+
+    @pytest.mark.asyncio
+    async def test_enrichment_lookup_failure_still_returns_shifts(self):
+        # Users/schedules are enrichment, not the answer. Losing them costs a
+        # display name; it must not fail the query.
+        shift = {
+            "id": "S1",
+            "attributes": {
+                "starts_at": "2026-08-02T00:00:00Z",
+                "ends_at": "2026-08-03T00:00:00Z",
+                "schedule_id": "s1",
+            },
+            "relationships": {"user": {"data": {"id": "u1"}}},
+        }
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                return _ok({"data": [shift], "meta": {"total_pages": 1}})
+            return _status(500)
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert not result.get("error"), result
+        assert result["total_shifts"] == 1
+
+
+class TestTruncationIsReported:
+    @pytest.mark.asyncio
+    async def test_hitting_the_page_ceiling_sets_a_flag(self):
+        # A full page plus a total_pages beyond max_pages means the result is
+        # partial; without a flag the caller cannot tell.
+        page = _full_page()
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                return _ok({"data": page, "meta": {"total_pages": 50}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert result["meta"]["truncated"] is True
+        note = result["meta"]["truncation_note"]
+        # The note has to say how much is missing, not just that some is.
+        assert "10 of 50 pages" in note
+
+    @pytest.mark.asyncio
+    async def test_truncation_across_windows_is_summed_not_overwritten(self):
+        # Windows run concurrently and each reports its own truncation. If the
+        # report were assigned rather than accumulated, one window's numbers
+        # would stand in for the whole query and understate what is missing.
+        page = _full_page()
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                # Two windows with different amounts of unfetched data.
+                total = 50 if (params or {}).get("from", "").startswith("2026-11") else 12
+                return _ok({"data": page, "meta": {"total_pages": total}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-11-01T00:00:00Z", to_date="2027-03-01T00:00:00Z"
+        )
+
+        note = result["meta"]["truncation_note"]
+        # 10 + 10 fetched of 50 + 12 available -- both windows counted.
+        assert "20 of 62 pages" in note
+
+    @pytest.mark.asyncio
+    async def test_a_fully_fetched_window_still_counts_toward_the_totals(self):
+        # The note describes query-wide totals, so a window that completed has
+        # to contribute its pages too -- counting only truncated windows
+        # understates how much was fetched and how much exists.
+        page = _full_page()
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                # One window completes in 3 pages; the other is cut at 10 of 50.
+                total = 3 if (params or {}).get("from", "").startswith("2026-11") else 50
+                return _ok({"data": page, "meta": {"total_pages": total}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-11-01T00:00:00Z", to_date="2027-03-01T00:00:00Z"
+        )
+
+        # 3 + 10 fetched of 3 + 50 available.
+        assert "13 of 53 pages" in result["meta"]["truncation_note"]
+
+    @pytest.mark.asyncio
+    async def test_windows_that_all_complete_report_no_truncation(self):
+        page = _full_page()
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                return _ok({"data": page, "meta": {"total_pages": 3}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-11-01T00:00:00Z", to_date="2027-03-01T00:00:00Z"
+        )
+
+        assert "truncated" not in result["meta"]
+        assert "truncation_note" not in result["meta"]
+
+
+class TestConcurrencyIsBounded:
+    @pytest.mark.asyncio
+    async def test_a_split_range_does_not_exceed_the_semaphore_limit(self):
+        # Every page request, including each window's first, goes through the
+        # semaphore. Leaving the first page unbounded would let the number of
+        # windows decide the real concurrency.
+        in_flight = 0
+        peak = 0
+        page = _full_page()
+
+        async def responder(method, path, params=None, **kwargs):
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0.001)
+            in_flight -= 1
+            if path == "/v1/shifts":
+                return _ok({"data": page, "meta": {"total_pages": 10}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-01-01T00:00:00Z", to_date="2026-12-31T00:00:00Z"
+        )
+
+        assert not result.get("error"), result
+        # Six windows of ten pages each, bounded by the tool's Semaphore(10).
+        assert peak <= 10
+
+    @pytest.mark.asyncio
+    async def test_a_failure_on_a_later_page_is_not_reported_as_complete(self):
+        # The first page succeeding does not make the answer complete. A page
+        # failing partway through returns a short list that reads as the whole
+        # result -- the same defect as the first page, just further in.
+        page = _full_page()
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                if (params or {}).get("page[number]") == 3:
+                    return _status(500)
+                return _ok({"data": page, "meta": {"total_pages": 5}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert result["error"] is True
+        assert "total_shifts" not in result
+
+    @pytest.mark.asyncio
+    async def test_a_later_page_failure_still_does_not_break_enrichment(self):
+        # Enrichment stays best-effort: a failed users page costs a display
+        # name, so it must not fail a query that has its shifts.
+        shift = {
+            "id": "S1",
+            "attributes": {
+                "starts_at": "2026-08-02T00:00:00Z",
+                "ends_at": "2026-08-03T00:00:00Z",
+                "schedule_id": "s1",
+            },
+            "relationships": {"user": {"data": {"id": "u1"}}},
+        }
+        users_page = [
+            {"id": f"u{i}", "type": "users", "attributes": {"full_name": "A", "email": "a@x"}}
+            for i in range(100)
+        ]
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                return _ok({"data": [shift], "meta": {"total_pages": 1}})
+            if path == "/v1/users":
+                if (params or {}).get("page[number]") == 2:
+                    return _status(500)
+                return _ok({"data": users_page, "meta": {"total_pages": 3}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert not result.get("error"), result
+        assert result["total_shifts"] == 1
+
+
+class TestHandoffSummarySchedulePages:
+    """The handoff summary's schedules are its answer, not enrichment."""
+
+    @pytest.mark.asyncio
+    async def test_a_failed_schedule_page_is_not_silently_omitted(self):
+        schedules = [
+            {"id": f"s{i}", "attributes": {"name": f"S{i}", "owner_group_ids": []}}
+            for i in range(100)
+        ]
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/schedules":
+                if (params or {}).get("page[number]") == 2:
+                    return _status(500)
+                return _ok({"data": schedules, "meta": {"total_pages": 3}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["get_oncall_handoff_summary"]()
+
+        # Dropping the page would omit whole schedules from the handoff while
+        # the result still read as the full picture.
+        assert result["error"] is True
+        assert "schedule pages" in str(result.get("message", ""))
+
+    @pytest.mark.asyncio
+    async def test_all_schedule_pages_succeeding_is_not_an_error(self):
+        schedules = [
+            {"id": f"s{i}", "attributes": {"name": f"S{i}", "owner_group_ids": []}}
+            for i in range(100)
+        ]
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/schedules":
+                return _ok({"data": schedules, "meta": {"total_pages": 2}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["get_oncall_handoff_summary"]()
+
+        assert not result.get("error"), result
+
+
+class TestPaginationMetadataTypes:
+    """Reporting must accept whatever pagination accepts, or a truncated
+    result comes back with nothing saying so."""
+
+    @staticmethod
+    def _page() -> list[dict[str, Any]]:
+        return _full_page()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("total_pages", [50, "50"])
+    async def test_truncation_is_reported_for_int_and_numeric_string(self, total_pages):
+        page = self._page()
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                return _ok({"data": page, "meta": {"total_pages": total_pages}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert result["meta"]["truncated"] is True
+        assert "10 of 50 pages" in result["meta"]["truncation_note"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("total_pages", [3, "3"])
+    async def test_a_complete_fetch_reports_no_truncation_either_way(self, total_pages):
+        page = self._page()
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                return _ok({"data": page, "meta": {"total_pages": total_pages}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert "truncated" not in result["meta"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("meta", [{}, {"total_pages": "abc"}])
+    async def test_an_unreported_page_count_with_full_pages_is_flagged(self, meta):
+        # Without a page count the ceiling is a guess. Every page coming back
+        # full is the only evidence more exist, and ten pages would otherwise
+        # read as the whole answer.
+        responder, _ = _responder(lambda _p: _ok({"data": _full_page(), "meta": meta}))
+        tools = _build_tools(responder)
+
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert result["meta"]["truncated"] is True
+        assert "an unreported number of" in result["meta"]["truncation_note"]
+
+    @pytest.mark.asyncio
+    async def test_an_unreported_page_count_with_a_short_page_is_not_flagged(self):
+        # A short page means the data ended; claiming truncation would be a
+        # false alarm on every small query.
+        responder, _ = _responder(
+            lambda _p: _ok({"data": [_shift(f"S{i}") for i in range(40)], "meta": {}})
+        )
+        tools = _build_tools(responder)
+
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert "truncated" not in result["meta"]
+
+
+class TestTransientFailureRetry:
+    """A split year is up to sixty requests, and any one failing fails the
+    query. One retry absorbs a blip without letting partial data through."""
+
+    @staticmethod
+    def _shift() -> dict[str, Any]:
+        return {
+            "id": "S1",
+            "attributes": {
+                "starts_at": "2026-08-02T00:00:00Z",
+                "ends_at": "2026-08-03T00:00:00Z",
+                "schedule_id": "s1",
+            },
+            "relationships": {"user": {"data": {"id": "u1"}}},
+        }
+
+    @pytest.mark.asyncio
+    async def test_a_transient_failure_is_retried_and_the_query_succeeds(self):
+        attempts = {"n": 0}
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    return _status(500)
+                return _ok({"data": [self._shift()], "meta": {"total_pages": 1}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert attempts["n"] == 2
+        assert not result.get("error"), result
+        assert result["total_shifts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_persistent_failure_is_retried_once_then_fails(self):
+        attempts = {"n": 0}
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                attempts["n"] += 1
+                return _status(500)
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert attempts["n"] == 2
+        assert result["error"] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [400, 403, 404, 422])
+    async def test_a_client_error_is_not_retried(self, status):
+        # The upstream said no; it will say no again. Retrying only doubles
+        # the load on a request that cannot succeed.
+        attempts = {"n": 0}
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                attempts["n"] += 1
+                return _status(status)
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert attempts["n"] == 1
+        assert result["error"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_missing_response_is_treated_as_transient(self):
+        attempts = {"n": 0}
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                attempts["n"] += 1
+                return None
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert attempts["n"] == 2
+        assert result["error"] is True

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -32,6 +32,7 @@ from rootly_mcp_server.tools.oncall import (  # noqa: E402
     METRICS_MAX_PAGES_PER_WINDOW,
     SHIFTS_FUTURE_HORIZON_DAYS,
     _date_argument_error,
+    _pages_fetched_phrase,
     _parse_iso_datetime,
     _shift_window_limit_days,
     _shifts_future_horizon_note,
@@ -1178,3 +1179,57 @@ class TestDateArgumentAliases:
         tool = {t.name: t for t in await mcp.list_tools()}["get_schedule_shifts"]
         schema = getattr(tool, "inputSchema", None) or getattr(tool, "parameters", None) or {}
         assert set(schema.get("properties", {})) == {"id", "start_date", "end_date"}
+
+
+class TestTruncationNoteWordsUnknownTotals:
+    """Every truncation note has to say the same thing about an unknown total.
+
+    The upstream does not always report `meta.total_pages`. Three notes were
+    written separately and drifted: two named the unknown, the third rendered
+    "10 of None pages", which reads as a defect in the answer rather than a
+    total nobody was given.
+    """
+
+    @staticmethod
+    def _responder_with_full_pages_and_no_total():
+        async def responder(method, path, params=None, **kwargs):
+            if path.endswith("/shifts"):
+                return _ok({"data": _full_page(), "meta": {}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        return responder
+
+    @pytest.mark.asyncio
+    async def test_list_shifts_names_the_unknown(self):
+        tools = _build_tools(self._responder_with_full_pages_and_no_total())
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+        note = result["meta"]["truncation_note"]
+        assert "an unreported number of pages" in note
+        assert "None" not in note
+
+    @pytest.mark.asyncio
+    async def test_schedule_shifts_names_the_unknown(self):
+        tools = _build_tools(self._responder_with_full_pages_and_no_total())
+        result = await tools["get_schedule_shifts"](
+            id="s1", start_date="2026-08-01T00:00:00Z", end_date="2026-08-20T00:00:00Z"
+        )
+        note = result["truncation_note"]
+        assert "an unreported number of pages" in note
+        assert "None" not in note
+
+    @pytest.mark.asyncio
+    async def test_metrics_names_the_unknown(self):
+        tools = _build_tools(self._responder_with_full_pages_and_no_total())
+        result = await tools["get_oncall_shift_metrics"](
+            start_date="2026-08-01T00:00:00Z", end_date="2026-08-20T00:00:00Z"
+        )
+        note = result["meta"]["truncation_note"]
+        assert "an unreported number of pages" in note
+        assert "None" not in note
+
+    def test_a_known_total_is_still_a_number(self):
+        assert (
+            _pages_fetched_phrase({"fetched_pages": 10, "available_pages": 50}) == "10 of 50 pages"
+        )

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -654,7 +654,7 @@ class TestPaginationMetadataTypes:
         )
 
         assert result["meta"]["truncated"] is True
-        assert "an unreported number of" in result["meta"]["truncation_note"]
+        assert "of at least " in result["meta"]["truncation_note"]
 
     @pytest.mark.asyncio
     async def test_an_unreported_page_count_with_a_short_page_is_not_flagged(self):
@@ -1206,7 +1206,7 @@ class TestTruncationNoteWordsUnknownTotals:
             from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
         )
         note = result["meta"]["truncation_note"]
-        assert "an unreported number of pages" in note
+        assert "of at least " in note
         assert "None" not in note
 
     @pytest.mark.asyncio
@@ -1216,7 +1216,7 @@ class TestTruncationNoteWordsUnknownTotals:
             id="s1", start_date="2026-08-01T00:00:00Z", end_date="2026-08-20T00:00:00Z"
         )
         note = result["truncation_note"]
-        assert "an unreported number of pages" in note
+        assert "of at least " in note
         assert "None" not in note
 
     @pytest.mark.asyncio
@@ -1226,7 +1226,7 @@ class TestTruncationNoteWordsUnknownTotals:
             start_date="2026-08-01T00:00:00Z", end_date="2026-08-20T00:00:00Z"
         )
         note = result["meta"]["truncation_note"]
-        assert "an unreported number of pages" in note
+        assert "of at least " in note
         assert "None" not in note
 
     def test_a_known_total_is_still_a_number(self):
@@ -1264,8 +1264,11 @@ class TestEveryWindowCountsTowardTheTotals:
 
         note = result["meta"]["truncation_note"]
         # 1 page from the short window, then the ceiling from each of the
-        # other two. Counting only the truncated windows would say 20.
-        assert "21 of 100 pages" in note
+        # other two. Counting only the truncated windows would say 20, and
+        # counting the short window in one half only would say "of 100".
+        # No "at least": a short page is the end of that window, so its one
+        # page is a known total, and the windows that truncated reported theirs.
+        assert "21 of 101 pages" in note
 
     @pytest.mark.asyncio
     async def test_an_untruncated_query_still_reports_no_truncation(self):

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -685,8 +685,8 @@ class TestCuratedScheduleShifts:
         # The exact range seen failing upstream.
         result = await tools["get_schedule_shifts"](
             id="f1dd57bb-2ba2-49cd-be00-64961b796b9e",
-            from_date="2026-07-30",
-            to_date="2026-09-28",
+            start_date="2026-07-30",
+            end_date="2026-09-28",
         )
 
         assert not result.get("error"), result
@@ -703,7 +703,7 @@ class TestCuratedScheduleShifts:
             lambda _p: _ok({"data": [_shift()], "meta": {"total_pages": 1}})
         )
         tools = _build_tools(responder)
-        await tools["get_schedule_shifts"](id="s1", from_date="2026-01-01", to_date="2026-06-30")
+        await tools["get_schedule_shifts"](id="s1", start_date="2026-01-01", end_date="2026-06-30")
 
         assert seen, "expected the range to be split into windows"
         for window in seen:
@@ -721,7 +721,7 @@ class TestCuratedScheduleShifts:
         )
         tools = _build_tools(responder)
         result = await tools["get_schedule_shifts"](
-            id="s1", from_date="2026-08-01", to_date="2026-08-20"
+            id="s1", start_date="2026-08-01", end_date="2026-08-20"
         )
 
         assert len(seen) == 1
@@ -736,7 +736,7 @@ class TestCuratedScheduleShifts:
 
         tools = _build_tools(responder)
         result = await tools["get_schedule_shifts"](
-            id="s1", from_date="2026-08-01", to_date="2026-08-20"
+            id="s1", start_date="2026-08-01", end_date="2026-08-20"
         )
 
         assert result["error"] is True
@@ -1002,7 +1002,7 @@ class TestUnusableDatesAreRejected:
     async def test_schedule_shifts_rejects_an_unusable_bound(self):
         responder, recorded = _responder()
         tools = _build_tools(responder)
-        result = await tools["get_schedule_shifts"](id="sched-1", from_date="whenever")
+        result = await tools["get_schedule_shifts"](id="sched-1", start_date="whenever")
 
         assert result["error"] is True
         assert recorded == []
@@ -1113,3 +1113,68 @@ class TestTransportErrorsAreRetried:
 
         assert attempts["n"] == 1
         assert result["error"] is True
+
+
+class TestDateArgumentAliases:
+    """The generated tool took `from`/`to`; most on-call tools take
+    `start_date`/`end_date`. A caller should not be turned away over spelling.
+
+    These go through a real FastMCP server because the aliases live in argument
+    validation -- calling the Python function directly bypasses them entirely.
+    """
+
+    @staticmethod
+    def _server(responder):
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("alias-probe")
+        register_oncall_tools(
+            mcp=mcp,
+            make_authenticated_request=AsyncMock(side_effect=responder),
+            mcp_error=FakeMCPError(),
+        )
+        return mcp
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "names",
+        [("start_date", "end_date"), ("from_date", "to_date"), ("from", "to")],
+    )
+    async def test_schedule_shifts_accepts_every_spelling(self, names):
+        start, end = names
+        responder, recorded = _responder(
+            lambda _p: _ok({"data": [_shift("S1")], "meta": {"total_pages": 1}})
+        )
+        mcp = self._server(responder)
+        await mcp.call_tool(
+            "get_schedule_shifts",
+            {"id": "sched-1", start: "2026-08-01T00:00:00Z", end: "2026-08-20T00:00:00Z"},
+        )
+
+        # Whichever spelling arrived, the same range reaches upstream.
+        assert recorded[0]["from"] == "2026-08-01T00:00:00Z"
+        assert recorded[0]["to"] == "2026-08-20T00:00:00Z"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("names", [("from_date", "to_date"), ("start_date", "end_date")])
+    async def test_list_shifts_accepts_either_convention(self, names):
+        start, end = names
+        responder, recorded = _responder(
+            lambda _p: _ok({"data": [_shift("S1")], "meta": {"total_pages": 1}})
+        )
+        mcp = self._server(responder)
+        await mcp.call_tool(
+            "list_shifts", {start: "2026-08-01T00:00:00Z", end: "2026-08-20T00:00:00Z"}
+        )
+
+        assert recorded[0]["from"] == "2026-08-01T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_the_schema_advertises_the_majority_convention(self):
+        # Five of the on-call tools name these start_date/end_date. Only the
+        # advertised name teaches a caller which to reach for.
+        responder, _ = _responder()
+        mcp = self._server(responder)
+        tool = {t.name: t for t in await mcp.list_tools()}["get_schedule_shifts"]
+        schema = getattr(tool, "inputSchema", None) or getattr(tool, "parameters", None) or {}
+        assert set(schema.get("properties", {})) == {"id", "start_date", "end_date"}

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock
@@ -27,8 +28,10 @@ from test_oncall_handoff import FakeMCP, FakeMCPError  # noqa: E402
 from rootly_mcp_server.exceptions import RootlyValidationError  # noqa: E402
 from rootly_mcp_server.tools.oncall import (  # noqa: E402
     MAX_SHIFT_SPAN_DAYS,
+    SHIFTS_FUTURE_HORIZON_DAYS,
     _parse_iso_datetime,
     _shift_window_limit_days,
+    _shifts_future_horizon_note,
     _split_date_windows,
     register_oncall_tools,
 )
@@ -133,6 +136,41 @@ class TestWindowLimits:
     )
     def test_non_shift_paths_are_not_split(self, path):
         assert _shift_window_limit_days(path) is None
+
+    def test_caps_are_the_largest_spans_upstream_accepts(self):
+        """Pin the measured values.
+
+        Upstream words these as "2 months" and "1 month", which invites 62 and
+        31. Both are rejected: against the live API, 60 and 30 pass while 61 and
+        31 return 422 from every start date tried, including February and
+        month-end. Windows built at 62/31 were each over the limit, so every
+        window of a split range failed and the split fixed nothing.
+        """
+        assert LIST_SHIFTS_LIMIT_DAYS == 60
+        assert SCHEDULE_SHIFTS_LIMIT_DAYS == 30
+
+
+class TestFutureHorizonNote:
+    """`/v1/shifts` serves generated shifts only, and says so with an empty list."""
+
+    def test_range_inside_the_horizon_is_not_annotated(self):
+        soon = datetime.now(UTC) + timedelta(days=SHIFTS_FUTURE_HORIZON_DAYS - 5)
+        assert _shifts_future_horizon_note(soon.isoformat()) is None
+
+    def test_range_beyond_the_horizon_is_annotated(self):
+        later = datetime.now(UTC) + timedelta(days=SHIFTS_FUTURE_HORIZON_DAYS + 30)
+        note = _shifts_future_horizon_note(later.isoformat())
+        assert note is not None
+        # The note has to name the tool that does cover those dates, or the
+        # caller is told the data is missing with nowhere to go.
+        assert "get_schedule_shifts" in note
+
+    def test_past_range_is_not_annotated(self):
+        assert _shifts_future_horizon_note("2020-01-01") is None
+
+    @pytest.mark.parametrize("value", ["", "garbage", None, 42])
+    def test_unparseable_end_is_not_annotated(self, value):
+        assert _shifts_future_horizon_note(value) is None
 
 
 class TestSplitDateWindows:

--- a/tests/unit/test_oncall_shift_windows.py
+++ b/tests/unit/test_oncall_shift_windows.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
+import httpx
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -1021,3 +1022,92 @@ class TestUnusableDatesAreRejected:
 
         assert result["error"] is True
         assert recorded == []
+
+
+class TestTransportErrorsAreRetried:
+    """A timeout arrives as a raised error, not as a response.
+
+    The retry originally inspected only what came back, so the failure that
+    actually happens on these endpoints -- pages take seconds each and a long
+    range is dozens of them -- left the loop before the second attempt.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_dropped_connection_is_retried_once(self):
+        attempts = {"n": 0}
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    raise httpx.ConnectError("connection reset")
+                return _ok({"data": [_shift("S1")], "meta": {"total_pages": 1}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert attempts["n"] == 2
+        assert not result.get("error")
+        assert result["total_shifts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_a_timeout_is_retried_once(self):
+        attempts = {"n": 0}
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    raise httpx.ReadTimeout("timed out")
+                return _ok({"data": [_shift("S1")], "meta": {"total_pages": 1}})
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert attempts["n"] == 2
+        assert not result.get("error")
+
+    @pytest.mark.asyncio
+    async def test_a_persistent_transport_error_still_fails_the_query(self):
+        # Two attempts is the budget. A partial answer must not slip through.
+        attempts = {"n": 0}
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                attempts["n"] += 1
+                raise httpx.ConnectError("down")
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert attempts["n"] == 2
+        assert result["error"] is True
+
+    @pytest.mark.asyncio
+    async def test_a_deterministic_error_is_not_retried(self):
+        # Retrying a bad request just doubles the load; only transport faults
+        # are worth a second attempt.
+        attempts = {"n": 0}
+
+        async def responder(method, path, params=None, **kwargs):
+            if path == "/v1/shifts":
+                attempts["n"] += 1
+                raise RootlyValidationError("bad range")
+            return _ok({"data": [], "meta": {"total_pages": 1}})
+
+        tools = _build_tools(responder)
+        result = await tools["list_shifts"](
+            from_date="2026-08-01T00:00:00Z", to_date="2026-08-20T00:00:00Z"
+        )
+
+        assert attempts["n"] == 1
+        assert result["error"] is True

--- a/tests/unit/test_transport_module.py
+++ b/tests/unit/test_transport_module.py
@@ -670,10 +670,13 @@ class TestTransportModule:
                 {"from": "2026-05-01", "to": "2026-07-31"},
             )
         msg = str(exc_info.value)
-        assert "31-day cap" in msg
+        # Derived from the constant: the cap is a measured upstream number, and
+        # hardcoding it here once made this test the only thing objecting when
+        # it was corrected.
+        assert f"{transport.SCHEDULE_SHIFTS_LIMIT_DAYS}-day cap" in msg
         assert "Split the query" in msg
 
-    def test_check_shift_date_range_blocks_over_62_day_listShifts(self):
+    def test_check_shift_date_range_blocks_over_cap_listShifts(self):
         with pytest.raises(RootlyValidationError):
             transport.AuthenticatedHTTPXClient._check_shift_date_range(
                 "GET",
@@ -682,7 +685,7 @@ class TestTransportModule:
             )
 
     def test_check_shift_date_range_allows_within_limit(self):
-        # 28 days on the schedule endpoint (limit 31) — must pass.
+        # 28 days on the schedule endpoint (limit 30) — must pass.
         transport.AuthenticatedHTTPXClient._check_shift_date_range(
             "GET",
             "https://api.rootly.com/v1/schedules/abc/shifts",


### PR DESCRIPTION
Fixes two customer reports.

**"60 days returns 0 shifts, but 30 and 45 return shifts."** Any non-200 on the first page was returned as an empty list, so an upstream failure looked exactly like an empty result. Fetches whose result is the answer now fail instead. Enrichment stays best-effort — a missing user map costs a display name, not the answer.

**"Claude says it can't look past October 2026, but the UI shows 2027."** The upstream rejects a shift range beyond its cap, so a longer range failed outright. Long ranges are now split into windows the API accepts and merged, in a single call.

## The caps were wrong

`/v1/shifts` says "2 months" and `/v1/schedules/{id}/shifts` says "1 month", which reads as 62 and 31. Both are rejected. Measured against the live API from five start dates, including February and a month end: **60 and 30 pass, 61 and 31 return 422**, regardless of the calendar months involved.

Every window was therefore built one day over the limit and 422'd individually. Splitting ran correctly and still returned nothing — the customer's 60-day query failed before and after. With 60/30 it returns the shifts.

## Also in here

- **Shift metrics could not chunk.** `get_oncall_shift_metrics` asked for the whole span in one request, so a quarterly report — the thing the tool exists for — was refused rather than assembled. It now uses the same windowed fetch.
- **An unusable date returned data.** `from_date="not-a-date"` came back with eleven real shifts presented as the requested period, because upstream ignores a malformed bound instead of rejecting it. Only values like `2026-13-45` earn a 400. Bounds are now checked before the request.
- **The retry did not cover the failure that happens.** It inspected what came back, but a timeout or dropped connection arrives as a raised error and left the loop untried. A page of `/v1/shifts` takes 4–12 seconds and a long range is dozens of them; three queries died this way in testing, including a 30-day range that was never even split.
- **A future range came back as a confident zero.** `/v1/shifts` only serves shifts that already exist, about a month ahead, and answers beyond that with an empty list rather than an error. Responses now say so and point at `get_schedule_shifts`, which derives shifts from rotations and has the data.
- The handoff summary silently dropped failed schedule pages, returning a summary missing whole schedules.
- Truncation is reported: past the page ceiling the caller was holding a partial result with no way to know.

## Interface changes

**`get_schedule_shifts` response shape.** A curated tool replaces the generated one, so it returns the same shape as the other on-call tools instead of the raw JSON:API envelope:

```jsonc
// before
{ "data": [ { "id": "...", "attributes": { ... } } ] }

// after
{ "schedule_id": "...",
  "period": { "from": "2026-06-13", "to": "2026-08-12" },
  "total_shifts": 10,
  "shifts": [ ... ] }
```

Anything reading `.data` needs `.shifts`. This is the one change that can fail quietly — a cached client gets a successful call in a shape it does not recognise. `period` is the point: the generated tool accepted a date range and ignored it, returning the same result for a 30-day and a 60-day query, and a caller had no way to tell.

**Parameter names.** `get_schedule_shifts` now advertises `start_date`/`end_date`, matching five of the seven on-call tools. It still accepts `from_date`/`to_date` and the generated tool's `from`/`to`, and `list_shifts` now accepts `start_date`/`end_date` as well, so no existing caller breaks. `from` is a reserved word, so the generated names could not have been kept regardless.

**Metrics pagination.** `get_oncall_shift_metrics` moved from one unpaginated request to paginated fetching. A window beyond roughly two thousand shifts now truncates where it previously did not — reported, not silent.

## Verified against the live API

| | before | after |
|---|---|---|
| `get_schedule_shifts` 60d (the report) | range ignored | 10 shifts, 2 windows |
| `list_shifts` 90d / 224d | refused | 1420 / 2970 |
| metrics 90d | refused | 1420, agrees with `list_shifts` |
| `get_oncall_schedule_summary` 90d | refused | works — untouched tool, fixed by the caps |
| 30d / 60d controls | 490 / 944 | identical |
| malformed date | 11 shifts | rejected |

A 61-day range spanning a window seam was reconciled against the raw API: union of 964 shifts, tool returned 964, metrics returned 964. Nothing lost at the boundary, nothing counted twice.

## Testing

845 tests. New behaviour was checked against the pre-change source to confirm it fails there — four of the metrics tests and three of the retry tests do. Alias tests run through a real MCP server rather than calling the functions directly, since argument validation is where aliases live.