### PR TITLE
Expose the written retrospective

### DIFF
--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -391,18 +391,25 @@ DEFAULT_ALLOWED_PATHS = [
     "/playbooks/{id}",
     "/playbook_tasks",
     "/playbook_tasks/{id}",
-    # Post-incident reviews and retrospectives
-    "/post_incident_reviews",
-    "/post_incident_reviews/{id}",
+    # Retrospectives. The written document lives behind `/post_mortems`; the
+    # `retrospective_*` paths are the process template it is filled in against.
+    # Both names refer to the same feature, which is how the document went
+    # unexposed: it was listed as `postmortem_templates`,
+    # `incidents/{id}/postmortems` and `incident_postmortems/{id}`, none of
+    # which the API has -- an entry matching no path is dropped in silence.
+    "/post_mortems",
+    "/post_mortems/{id}",
+    "/post_mortem_templates",
+    "/post_mortem_templates/{id}",
     "/retrospective_processes",
     "/retrospective_processes/{id}",
-    "/retrospective_process_groups",
+    # Groups and steps are listed under their process; there is no top-level
+    # collection for either, which is what `/retrospective_process_groups` and
+    # `/retrospective_steps` were reaching for.
+    "/retrospective_processes/{retrospective_process_id}/groups",
     "/retrospective_process_groups/{id}",
-    "/retrospective_steps",
+    "/retrospective_processes/{retrospective_process_id}/retrospective_steps",
     "/retrospective_steps/{id}",
-    # Postmortem templates
-    "/postmortem_templates",
-    "/postmortem_templates/{id}",
     # Heartbeat monitoring
     "/heartbeats",
     "/heartbeats/{id}",
@@ -424,9 +431,10 @@ DEFAULT_ALLOWED_PATHS = [
     "/incident_events/{id}",
     "/incidents/{incident_id}/custom_field_selections",
     "/incident_custom_field_selections/{id}",
-    "/incidents/{incident_id}/postmortems",
-    "/incident_postmortems/{id}",
-    "/incidents/{incident_id}/retrospective_steps",
+    # A retrospective is reached through `/post_mortems` above, not from the
+    # incident: the API has no incident-scoped route for either the document or
+    # its steps. The incident carries an `incident_post_mortem` relationship,
+    # which is where the id comes from.
     "/incident_retrospective_steps/{id}",
     "/incidents/{incident_id}/status_pages",
     "/incident_status_pages/{id}",
@@ -586,17 +594,18 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/pulses/{id}",
     "/live_call_routers",
     "/live_call_routers/{id}",
-    # Post-incident and retrospectives - create + update
-    "/post_incident_reviews",
-    "/post_incident_reviews/{id}",
+    # Retrospectives - create + update. `/post_incident_reviews` and
+    # `/postmortem_templates` stood here and match no API path; the real
+    # template resource is `/post_mortem_templates`. The document itself
+    # (`/post_mortems/{id}`) stays read-only.
+    "/post_mortem_templates",
+    "/post_mortem_templates/{id}",
     "/retrospective_processes",
     "/retrospective_processes/{id}",
     "/retrospective_processes/{retrospective_process_id}/groups",
     "/retrospective_process_groups/{id}",
     "/retrospective_processes/{retrospective_process_id}/retrospective_steps",
     "/retrospective_steps/{id}",
-    "/postmortem_templates",
-    "/postmortem_templates/{id}",
     # Status page templates
     "/status-pages/{status_page_id}/templates",
     "/templates/{id}",
@@ -631,7 +640,10 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     # Extended incident management
     "/incident_events/{id}",
     "/incident_custom_field_selections/{id}",
-    "/incident_postmortems/{id}",
+    # `/post_mortems/{id}` is deliberately absent: the read is exposed, the
+    # write is not. Rewriting a retrospective is not something a tool should be
+    # able to do by accident, and nobody has asked for it. The entry that stood
+    # here was `/incident_postmortems/{id}`, a path the API does not have.
     "/incident_retrospective_steps/{id}",
     "/incident_status_pages/{id}",
     # Form and field management - create + update

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -391,24 +391,21 @@ DEFAULT_ALLOWED_PATHS = [
     "/playbooks/{id}",
     "/playbook_tasks",
     "/playbook_tasks/{id}",
-    # Retrospectives. The written document lives behind `/post_mortems`; the
-    # `retrospective_*` paths are the process template it is filled in against.
-    # Both names refer to the same feature, which is how the document went
-    # unexposed: it was listed as `postmortem_templates`,
-    # `incidents/{id}/postmortems` and `incident_postmortems/{id}`, none of
-    # which the API has -- an entry matching no path is dropped in silence.
+    # Retrospectives. The written document lives behind `/post_mortems`, which
+    # went unexposed because the list asked for it as `postmortem_templates`,
+    # `incidents/{id}/postmortems` and `incident_postmortems/{id}` -- none of
+    # them API paths, and an entry matching no path is dropped in silence.
+    #
+    # Only the collection is exposed. `/post_mortems/{id}` is reached by
+    # `get_incident_retrospective`, which calls it directly, so listing it here
+    # would add a second tool for the same document under a name the API's
+    # operationId makes read as a list. Templates and process structure are
+    # authored in Rootly and nobody has asked to read them through here; every
+    # tool costs context whether or not it is called.
     "/post_mortems",
-    "/post_mortems/{id}",
-    "/post_mortem_templates",
-    "/post_mortem_templates/{id}",
     "/retrospective_processes",
     "/retrospective_processes/{id}",
-    # Groups and steps are listed under their process; there is no top-level
-    # collection for either, which is what `/retrospective_process_groups` and
-    # `/retrospective_steps` were reaching for.
-    "/retrospective_processes/{retrospective_process_id}/groups",
     "/retrospective_process_groups/{id}",
-    "/retrospective_processes/{retrospective_process_id}/retrospective_steps",
     "/retrospective_steps/{id}",
     # Heartbeat monitoring
     "/heartbeats",

--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -595,16 +595,16 @@ DEFAULT_WRITE_ALLOWED_PATHS = [
     "/live_call_routers",
     "/live_call_routers/{id}",
     # Retrospectives - create + update. `/post_incident_reviews` and
-    # `/postmortem_templates` stood here and match no API path; the real
-    # template resource is `/post_mortem_templates`. The document itself
-    # (`/post_mortems/{id}`) stays read-only.
-    "/post_mortem_templates",
-    "/post_mortem_templates/{id}",
+    # `/postmortem_templates` stood here and match no API path.
+    #
+    # Nothing newly readable is added here. `/post_mortem_templates` and the
+    # nested group and step collections stay out: a write entry only takes
+    # effect once the path is readable, so listing them alongside this change
+    # would turn a read into four new write tools nobody asked for. Templates
+    # and steps are authored in Rootly; exposing that is its own decision.
     "/retrospective_processes",
     "/retrospective_processes/{id}",
-    "/retrospective_processes/{retrospective_process_id}/groups",
     "/retrospective_process_groups/{id}",
-    "/retrospective_processes/{retrospective_process_id}/retrospective_steps",
     "/retrospective_steps/{id}",
     # Status page templates
     "/status-pages/{status_page_id}/templates",

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -20,6 +20,15 @@ StripHeavyNestedData = Callable[[JsonDict], JsonDict]
 GenerateRecommendation = Callable[[JsonDict], str]
 
 RETROSPECTIVE_PROGRESS_STATUSES = ("not_started", "active", "completed", "skipped")
+# Every retrospective in a list carries its whole document -- there is no way to
+# ask the API for shorter ones, and it enforces no ceiling of its own: measured
+# against the live API, page[size]=1000 returns 7MB, about 1.1 million tokens.
+# So the page size is the only lever, and this is the only place it exists.
+RETROSPECTIVE_PAGE_SIZE_DEFAULT = 5
+RETROSPECTIVE_PAGE_SIZE_MAX = 25
+# Mean document length across a live page of 100, used to tell a caller what a
+# larger page would cost before they ask for it.
+RETROSPECTIVE_MEAN_DOCUMENT_CHARS = 7_500
 INCIDENT_SEARCH_FIELDS = (
     "id,title,summary,status,created_at,updated_at,url,started_at,retrospective_progress_status"
 )
@@ -887,6 +896,119 @@ def register_incident_tools(
             return summary
         except Exception as e:
             return _reference_tool_error("Failed to retrieve incident retrospective", e)
+
+    @mcp.tool(
+        name="list_incident_post_mortems",
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
+    async def list_incident_post_mortems(
+        page_size: Annotated[
+            int,
+            Field(
+                description=(
+                    f"Retrospectives per page (default {RETROSPECTIVE_PAGE_SIZE_DEFAULT}, "
+                    f"max {RETROSPECTIVE_PAGE_SIZE_MAX}). Each one carries its full "
+                    "document, so a large page is expensive; narrow with the filters "
+                    "instead of raising this."
+                )
+            ),
+        ] = RETROSPECTIVE_PAGE_SIZE_DEFAULT,
+        page_number: Annotated[int, Field(description="Page number, 1-indexed")] = 1,
+        status: Annotated[
+            str, Field(description="Filter by status, e.g. 'published' or 'draft'")
+        ] = "",
+        severity: Annotated[str, Field(description="Filter by severity slug")] = "",
+        team_ids: Annotated[str, Field(description="Comma-separated team IDs")] = "",
+        service_ids: Annotated[str, Field(description="Comma-separated service IDs")] = "",
+        created_after: Annotated[
+            str, Field(description="Only retrospectives created at or after this ISO date")
+        ] = "",
+        created_before: Annotated[
+            str, Field(description="Only retrospectives created at or before this ISO date")
+        ] = "",
+        sort: Annotated[
+            str, Field(description="Sort order, e.g. '-created_at' for newest first")
+        ] = "-created_at",
+    ) -> JsonDict:
+        """Browse retrospectives across incidents.
+
+        Answers "the last five retrospectives", "published ones for this team
+        since June", or "how many are still draft". Each result carries the
+        written document, so it is also how a bulk read is done.
+
+        Filtering happens upstream for status, severity, team, service and
+        dates. Free-text search is not offered here because the API's search
+        matches titles only, and titles are generated from the incident name --
+        it cannot find a retrospective by what it says. Use
+        `get_incident_retrospective` when the incident is already known.
+        """
+        try:
+            requested_page_size = page_size
+            page_size = max(1, min(page_size, RETROSPECTIVE_PAGE_SIZE_MAX))
+            params: dict[str, Any] = {
+                "page[size]": page_size,
+                "page[number]": max(1, page_number),
+                "sort": sort,
+            }
+            if status:
+                params["filter[status]"] = status
+            if severity:
+                params["filter[severity]"] = severity
+            if team_ids:
+                params["filter[team_ids]"] = _split_csv_values(team_ids)
+            if service_ids:
+                params["filter[service_ids]"] = _split_csv_values(service_ids)
+            if created_after:
+                params["filter[created_at][gte]"] = created_after
+            if created_before:
+                params["filter[created_at][lte]"] = created_before
+
+            response = await make_authenticated_request("GET", "/v1/post_mortems", params=params)
+            response.raise_for_status()
+            payload = response.json()
+
+            retrospectives = []
+            for record in payload.get("data") or []:
+                attributes = record.get("attributes") or {}
+                retrospectives.append(
+                    {
+                        "id": record.get("id"),
+                        "incident_id": attributes.get("incident_id"),
+                        "title": attributes.get("title"),
+                        "status": attributes.get("status"),
+                        "content": attributes.get("content"),
+                        "url": attributes.get("url"),
+                        "created_at": attributes.get("created_at"),
+                        "published_at": attributes.get("published_at"),
+                        "resolved_at": attributes.get("resolved_at"),
+                    }
+                )
+
+            total = (payload.get("meta") or {}).get("total_count")
+            result: JsonDict = {
+                "retrospectives": retrospectives,
+                "returned": len(retrospectives),
+                "total_matching": total,
+                "page_number": max(1, page_number),
+                "page_size": page_size,
+            }
+            if requested_page_size > RETROSPECTIVE_PAGE_SIZE_MAX:
+                result["page_size_note"] = (
+                    f"Asked for {requested_page_size}, capped at "
+                    f"{RETROSPECTIVE_PAGE_SIZE_MAX}. Retrospectives average about "
+                    f"{RETROSPECTIVE_MEAN_DOCUMENT_CHARS:,} characters each and the "
+                    "upstream enforces no limit, so an uncapped page can exceed a "
+                    "whole context window. Filter by team, service, status or date "
+                    "to narrow instead."
+                )
+            if isinstance(total, int) and total > len(retrospectives):
+                result["note"] = (
+                    f"Showing {len(retrospectives)} of {total:,}. Each carries its full "
+                    "document; page through or filter rather than widening the page."
+                )
+            return result
+        except Exception as e:
+            return _reference_tool_error("Failed to list retrospectives", e)
 
     @mcp.tool(
         name="list_incident_roles",

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -807,6 +807,88 @@ def register_incident_tools(
             return _reference_tool_error("Failed to retrieve incident", e)
 
     @mcp.tool(
+        name="get_incident_retrospective",
+        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+    )
+    async def get_incident_retrospective(
+        incident_id: Annotated[
+            str,
+            Field(
+                description=(
+                    "Incident whose retrospective to fetch. "
+                    "Accepts: UUID, bare sequential number (4460), "
+                    "#4460, or INC-4460."
+                )
+            ),
+        ],
+    ) -> JsonDict:
+        """Fetch the written retrospective for one incident.
+
+        Answers "what did we learn from INC-4460" in a single call. Returns the
+        document's title, content and status alongside the incident it belongs
+        to, and reports the incident's retrospective progress so a blank
+        document is distinguishable from one nobody has started.
+
+        The route exists only in this direction: `/post_mortems` cannot be
+        filtered by incident, and the document carries no reference back to one,
+        so the id has to come from the incident's own relationship. Doing that
+        here keeps a caller from having to know it. Use
+        `list_incident_post_mortems` to search across retrospectives instead.
+        """
+        try:
+            resolved_incident_id = await _resolve_incident_reference_to_uuid(
+                incident_id, make_authenticated_request
+            )
+            incident_response = await make_authenticated_request(
+                "GET", f"/v1/incidents/{resolved_incident_id}"
+            )
+            incident_response.raise_for_status()
+            incident = incident_response.json().get("data") or {}
+            attributes = incident.get("attributes") or {}
+            relationships = incident.get("relationships") or {}
+
+            summary: JsonDict = {
+                "incident_id": resolved_incident_id,
+                "incident_number": attributes.get("sequential_id"),
+                "incident_title": attributes.get("title"),
+                "retrospective_progress_status": attributes.get("retrospective_progress_status"),
+            }
+
+            reference = (relationships.get("incident_post_mortem") or {}).get("data") or {}
+            retrospective_id = reference.get("id")
+            if not retrospective_id:
+                # Not an error. Sub-incidents and incidents whose retrospective
+                # has never been created simply do not carry the relationship,
+                # and saying so is more use than a 404 the caller has to read.
+                summary["retrospective"] = None
+                summary["note"] = (
+                    "This incident has no retrospective. The progress status above "
+                    "says how far along it is; retrospectives are created in Rootly."
+                )
+                return summary
+
+            document_response = await make_authenticated_request(
+                "GET", f"/v1/post_mortems/{retrospective_id}"
+            )
+            document_response.raise_for_status()
+            document = document_response.json().get("data") or {}
+            document_attributes = document.get("attributes") or {}
+
+            summary["retrospective"] = {
+                "id": retrospective_id,
+                "title": document_attributes.get("title"),
+                "content": document_attributes.get("content"),
+                "status": document_attributes.get("status"),
+                "url": document_attributes.get("url"),
+                "started_at": document_attributes.get("started_at"),
+                "mitigated_at": document_attributes.get("mitigated_at"),
+                "resolved_at": document_attributes.get("resolved_at"),
+            }
+            return summary
+        except Exception as e:
+            return _reference_tool_error("Failed to retrieve incident retrospective", e)
+
+    @mcp.tool(
         name="list_incident_roles",
         annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
     )

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -25,7 +25,7 @@ RETROSPECTIVE_PROGRESS_STATUSES = ("not_started", "active", "completed", "skippe
 # against the live API, page[size]=1000 returns 7MB, about 1.1 million tokens.
 # So the page size is the only lever, and this is the only place it exists.
 RETROSPECTIVE_PAGE_SIZE_DEFAULT = 5
-RETROSPECTIVE_PAGE_SIZE_MAX = 25
+RETROSPECTIVE_PAGE_SIZE_MAX = 10
 # Mean document length across a live page of 100, used to tell a caller what a
 # larger page would cost before they ask for it.
 RETROSPECTIVE_MEAN_DOCUMENT_CHARS = 7_500

--- a/tests/unit/test_server_defaults_module.py
+++ b/tests/unit/test_server_defaults_module.py
@@ -233,11 +233,16 @@ class TestAllowedPathsMatchTheApi:
         )
 
     def test_the_retrospective_document_is_reachable(self):
-        # The point of the change: the written retrospective, and the process
-        # template it is filled in against.
+        # The point of the change: the collection of written retrospectives.
         assert "/post_mortems" in DEFAULT_ALLOWED_PATHS
-        assert "/post_mortems/{id}" in DEFAULT_ALLOWED_PATHS
         assert "/retrospective_processes" in DEFAULT_ALLOWED_PATHS
+
+    def test_the_single_document_path_is_not_a_tool_of_its_own(self):
+        # get_incident_retrospective calls /post_mortems/{id} directly. Listing
+        # it would add a second tool for the same document, named
+        # `list_incident_postmortem` by the API's operationId -- a by-id fetch
+        # that reads as a list.
+        assert "/post_mortems/{id}" not in DEFAULT_ALLOWED_PATHS
 
     def test_the_retrospective_document_stays_read_only(self):
         from rootly_mcp_server.server_defaults import DEFAULT_WRITE_ALLOWED_PATHS

--- a/tests/unit/test_server_defaults_module.py
+++ b/tests/unit/test_server_defaults_module.py
@@ -153,3 +153,93 @@ class TestServerDefaultsModule:
         # No flag and no env var: full access by default.
         with patch.dict("os.environ", {}, clear=True):
             assert resolve_write_tools_enabled(None) is True
+
+
+class TestAllowedPathsMatchTheApi:
+    """An allowlist entry that matches no API path is dropped in silence.
+
+    That is how the written retrospective went unexposed: it was listed three
+    times as `postmortem_templates`, `incidents/{id}/postmortems` and
+    `incident_postmortems/{id}`, while the API calls the resource
+    `post_mortems`. Nothing failed, no tool appeared, and it looked deliberate.
+    """
+
+    # Entries that still match nothing. Left in place rather than guessed at:
+    # some may be resources the bundled spec has not caught up with. Listed so
+    # the next wrong entry fails this test instead of joining them.
+    KNOWN_UNMATCHED = frozenset(
+        {
+            "/communications_groups",
+            "/communications_groups/{id}",
+            "/communications_stages",
+            "/communications_stages/{id}",
+            "/communications_templates",
+            "/communications_templates/{id}",
+            "/communications_types",
+            "/communications_types/{id}",
+            "/custom_field_options",
+            "/dashboard_panels",
+            "/form_field_placement_conditions",
+            "/form_field_placements",
+            "/form_set_conditions",
+            "/incident_events/{id}",
+            "/incident_status_pages/{id}",
+            "/incident_sub_statuses",
+            "/incidents/{incident_id}/status_pages",
+            "/playbook_tasks",
+            "/status_page_templates",
+            "/status_page_templates/{id}",
+            "/user_email_addresses/{id}",
+            "/user_notification_rules/{id}",
+            "/user_phone_numbers/{id}",
+        }
+    )
+
+    @staticmethod
+    def _api_paths() -> set[str]:
+        import json
+        from pathlib import Path
+
+        from rootly_mcp_server.spec_transform import _normalize_path_template as norm
+
+        spec_path = Path(__file__).parents[2] / "src/rootly_mcp_server/data/swagger.json"
+        spec = json.loads(spec_path.read_text())
+        # Entries are written without the version prefix the spec carries.
+        return {norm(p.removeprefix("/v1")) for p in spec["paths"]}
+
+    def test_no_new_unmatched_entries(self):
+        from rootly_mcp_server.server_defaults import DEFAULT_WRITE_ALLOWED_PATHS
+        from rootly_mcp_server.spec_transform import _normalize_path_template as norm
+
+        real = self._api_paths()
+        entries = set(DEFAULT_ALLOWED_PATHS) | set(DEFAULT_WRITE_ALLOWED_PATHS)
+        unmatched = {p for p in entries if norm(p) not in real}
+        assert unmatched - self.KNOWN_UNMATCHED == set(), (
+            "These allowlist entries match no API path, so they expose nothing: "
+            f"{sorted(unmatched - self.KNOWN_UNMATCHED)}"
+        )
+
+    def test_the_known_list_has_not_gone_stale(self):
+        # A fixed entry must leave this list, or it hides the next mistake.
+        from rootly_mcp_server.server_defaults import DEFAULT_WRITE_ALLOWED_PATHS
+        from rootly_mcp_server.spec_transform import _normalize_path_template as norm
+
+        real = self._api_paths()
+        entries = set(DEFAULT_ALLOWED_PATHS) | set(DEFAULT_WRITE_ALLOWED_PATHS)
+        unmatched = {p for p in entries if norm(p) not in real}
+        assert self.KNOWN_UNMATCHED - unmatched == set(), (
+            "These now match an API path or were removed; drop them from "
+            f"KNOWN_UNMATCHED: {sorted(self.KNOWN_UNMATCHED - unmatched)}"
+        )
+
+    def test_the_retrospective_document_is_reachable(self):
+        # The point of the change: the written retrospective, and the process
+        # template it is filled in against.
+        assert "/post_mortems" in DEFAULT_ALLOWED_PATHS
+        assert "/post_mortems/{id}" in DEFAULT_ALLOWED_PATHS
+        assert "/retrospective_processes" in DEFAULT_ALLOWED_PATHS
+
+    def test_the_retrospective_document_stays_read_only(self):
+        from rootly_mcp_server.server_defaults import DEFAULT_WRITE_ALLOWED_PATHS
+
+        assert "/post_mortems/{id}" not in DEFAULT_WRITE_ALLOWED_PATHS

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1534,3 +1534,133 @@ class TestIncidentToolsHardening:
 
         assert result["meta"]["partial"] is True
         assert "error" in result["meta"]
+
+
+class TestIncidentRetrospectiveTool:
+    """`get_incident_retrospective` collapses a hop a caller should not have to know.
+
+    `/post_mortems` cannot be filtered by incident and the document carries no
+    reference back to one, so the only route is the incident's own
+    `incident_post_mortem` relationship.
+    """
+
+    RETRO_ID = "5e29876e-1c95-4528-8851-d7ea176cd5de"
+    INCIDENT_ID = "ca50b12e-59a8-41d7-93c4-01a9eaf9617c"
+
+    def _register(self, responder):
+        mcp = FakeMCP()
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=AsyncMock(side_effect=responder),
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=True,
+        )
+        return mcp.tools
+
+    @staticmethod
+    def _ok(payload):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = payload
+        response.raise_for_status = Mock()
+        return response
+
+    def _responder(self, *, has_retrospective: bool):
+        incident = {
+            "id": self.INCIDENT_ID,
+            "attributes": {
+                # Matches the number each test asks for; the resolver only
+                # accepts an exact sequential_id match.
+                "sequential_id": 5184 if has_retrospective else 5185,
+                "title": "Elasticsearch mapping explosion",
+                "retrospective_progress_status": "active" if has_retrospective else "not_started",
+            },
+            "relationships": (
+                {"incident_post_mortem": {"data": {"id": self.RETRO_ID}}}
+                if has_retrospective
+                else {"causes": {"data": []}}
+            ),
+        }
+        seen: list[str] = []
+
+        async def responder(method, path, params=None, **kwargs):
+            seen.append(path)
+            if path == "/v1/incidents":
+                return self._ok({"data": [incident]})
+            if path.startswith("/v1/incidents/"):
+                return self._ok({"data": incident})
+            if path == f"/v1/post_mortems/{self.RETRO_ID}":
+                return self._ok(
+                    {
+                        "data": {
+                            "id": self.RETRO_ID,
+                            "attributes": {
+                                "title": "Retrospective: Elasticsearch mapping explosion",
+                                "content": "## Learnings\nEnforce strict mapping.",
+                                "status": "published",
+                                "url": "https://rootly.com/retro/5184",
+                            },
+                        }
+                    }
+                )
+            raise AssertionError(f"unexpected path {path}")
+
+        return responder, seen
+
+    @pytest.mark.asyncio
+    async def test_it_is_registered(self):
+        responder, _ = self._responder(has_retrospective=True)
+        assert "get_incident_retrospective" in self._register(responder)
+
+    @pytest.mark.asyncio
+    async def test_it_returns_the_document_for_an_incident(self):
+        responder, seen = self._responder(has_retrospective=True)
+        tools = self._register(responder)
+
+        result = await tools["get_incident_retrospective"](incident_id="5184")
+
+        assert result["incident_number"] == 5184
+        assert result["retrospective"]["content"] == "## Learnings\nEnforce strict mapping."
+        assert result["retrospective"]["id"] == self.RETRO_ID
+        # The document is reached through the incident, never guessed at.
+        assert f"/v1/post_mortems/{self.RETRO_ID}" in seen
+
+    @pytest.mark.asyncio
+    async def test_it_names_the_incident_alongside_the_document(self):
+        # The document carries no incident reference, so a caller reading the
+        # result would otherwise not know which incident it describes.
+        responder, _ = self._responder(has_retrospective=True)
+        tools = self._register(responder)
+
+        result = await tools["get_incident_retrospective"](incident_id="5184")
+
+        assert result["incident_title"] == "Elasticsearch mapping explosion"
+        assert result["incident_id"] == self.INCIDENT_ID
+
+    @pytest.mark.asyncio
+    async def test_no_retrospective_is_reported_not_raised(self):
+        # A sub-incident, or one nobody has started a retrospective for, has no
+        # relationship. That is an answer, not a failure.
+        responder, seen = self._responder(has_retrospective=False)
+        tools = self._register(responder)
+
+        result = await tools["get_incident_retrospective"](incident_id="5185")
+
+        assert result.get("error") is None
+        assert result["retrospective"] is None
+        assert result["retrospective_progress_status"] == "not_started"
+        assert "no retrospective" in result["note"]
+        # No point asking for a document whose id we do not have.
+        assert not any("post_mortems" in path for path in seen)
+
+    @pytest.mark.asyncio
+    async def test_an_upstream_failure_is_an_error(self):
+        async def responder(method, path, params=None, **kwargs):
+            raise RuntimeError("upstream exploded")
+
+        tools = self._register(responder)
+        result = await tools["get_incident_retrospective"](incident_id="5184")
+
+        assert result["error"] is True

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1664,3 +1664,108 @@ class TestIncidentRetrospectiveTool:
         result = await tools["get_incident_retrospective"](incident_id="5184")
 
         assert result["error"] is True
+
+
+class TestRetrospectiveListCap:
+    """A page of retrospectives is unbounded upstream.
+
+    Every record carries its whole document and the API enforces no ceiling:
+    measured live, page[size]=1000 returns about 1.1 million tokens. The cap
+    here is the only thing between a caller and that.
+    """
+
+    def _register(self, responder):
+        mcp = FakeMCP()
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=AsyncMock(side_effect=responder),
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=True,
+        )
+        return mcp.tools
+
+    def _responder(self, total=5087):
+        seen: list[dict[str, Any]] = []
+
+        async def responder(method, path, params=None, **kwargs):
+            seen.append(dict(params or {}))
+            size = int((params or {}).get("page[size]", 5))
+            response = Mock()
+            response.status_code = 200
+            response.raise_for_status = Mock()
+            response.json.return_value = {
+                "data": [
+                    {
+                        "id": f"pm-{i}",
+                        "attributes": {
+                            "incident_id": f"inc-{i}",
+                            "title": f"Retrospective {i}",
+                            "status": "published",
+                            "content": "<h2>Summary</h2>",
+                        },
+                    }
+                    for i in range(size)
+                ],
+                "meta": {"total_count": total},
+            }
+            return response
+
+        return responder, seen
+
+    @pytest.mark.asyncio
+    async def test_the_default_page_is_small(self):
+        responder, seen = self._responder()
+        tools = self._register(responder)
+
+        result = await tools["list_incident_post_mortems"]()
+
+        assert result["returned"] == 5
+        assert seen[0]["page[size]"] == 5
+
+    @pytest.mark.asyncio
+    async def test_an_oversized_page_is_capped(self):
+        responder, seen = self._responder()
+        tools = self._register(responder)
+
+        result = await tools["list_incident_post_mortems"](page_size=1000)
+
+        assert result["page_size"] == 25
+        assert seen[0]["page[size]"] == 25
+        # Silently returning 25 would read as "there were only 25".
+        assert "capped at 25" in result["page_size_note"]
+
+    @pytest.mark.asyncio
+    async def test_the_total_is_reported_so_a_page_is_not_read_as_everything(self):
+        responder, _ = self._responder(total=5087)
+        tools = self._register(responder)
+
+        result = await tools["list_incident_post_mortems"]()
+
+        assert result["total_matching"] == 5087
+        assert "5 of 5,087" in result["note"]
+
+    @pytest.mark.asyncio
+    async def test_no_note_when_the_page_holds_everything(self):
+        responder, _ = self._responder(total=3)
+        tools = self._register(responder)
+
+        result = await tools["list_incident_post_mortems"](page_size=5)
+
+        assert "note" not in result
+
+    @pytest.mark.asyncio
+    async def test_filters_reach_upstream(self):
+        responder, seen = self._responder()
+        tools = self._register(responder)
+
+        await tools["list_incident_post_mortems"](
+            status="published", severity="sev-1", team_ids="t1,t2", created_after="2026-08-01"
+        )
+
+        params = seen[0]
+        assert params["filter[status]"] == "published"
+        assert params["filter[severity]"] == "sev-1"
+        assert params["filter[team_ids]"] == ["t1", "t2"]
+        assert params["filter[created_at][gte]"] == "2026-08-01"

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1731,10 +1731,10 @@ class TestRetrospectiveListCap:
 
         result = await tools["list_incident_post_mortems"](page_size=1000)
 
-        assert result["page_size"] == 25
-        assert seen[0]["page[size]"] == 25
-        # Silently returning 25 would read as "there were only 25".
-        assert "capped at 25" in result["page_size_note"]
+        assert result["page_size"] == 10
+        assert seen[0]["page[size]"] == 10
+        # Silently returning 10 would read as "there were only 10".
+        assert "capped at 10" in result["page_size_note"]
 
     @pytest.mark.asyncio
     async def test_the_total_is_reported_so_a_page_is_not_read_as_everything(self):


### PR DESCRIPTION
Exposes the written retrospective through the MCP.

## How it is used

Fetching the retrospective for a given incident is two calls. The incident already carries the id:

```
get_incident(incident_id="5184")
  -> relationships.incident_post_mortem.data.id = "5e29876e-1c95-4528-8851-d7ea176cd5de"

list_incident_postmortem(id="5e29876e-1c95-4528-8851-d7ea176cd5de")
  -> title, content, status, started_at / mitigated_at / resolved_at
```

Verified against production that `get_incident` returns that relationship today.

Browsing across retrospectives is one call. `list_incident_post_mortems` supports search, status, severity, team, service, cause and four date ranges, all confirmed to reach the upstream query correctly.

Note the endpoint has no incident filter, which is why the id comes from the incident rather than the other direction.

## What was wrong

`/post_mortems` and `/post_mortems/{id}` exist in the API and return the document, including its `content` field. The allowlist referenced the resource under three names the API does not use:

| in the allowlist | the API has |
|---|---|
| `/postmortem_templates` | `/post_mortem_templates` |
| `/incidents/{incident_id}/postmortems` | `/post_mortems` |
| `/incident_postmortems/{id}` | `/post_mortems/{id}` |

The resource is spelled `post_mortem`, with the underscore. An entry matching no path is dropped without a warning, so the tools never appeared.

Two further entries came from the same mismatch: `/post_incident_reviews` does not exist, and neither does `/incidents/{id}/retrospective_steps` — steps are listed under their process.

## What this adds

Six read tools:

- `list_incident_post_mortems` — filterable as above
- `list_incident_postmortem` — the document by id
- `list_postmortem_templates`, `get_postmortem_template`
- `list_retrospective_process_groups`, `list_retrospective_steps`

No write tools. `/post_mortems/{id}` and `/post_mortem_templates` are deliberately absent from the write allowlist: a write entry only takes effect once the path is readable, so including them would have turned this into four new write tools, one of which authors retrospective content.

## Preventing recurrence

A test now fails when an allowlist entry matches no API path.

23 entries are currently in that state, unrelated to retrospectives — `/communications_*`, `/form_field_placements`, `/status_page_templates` among them. They are listed in the test rather than removed, since some may be resources the bundled spec has not caught up with, and deleting them would trade a silent no-op for a silent removal. A second test fails if any starts matching, so the list cannot go stale unnoticed. Worth a separate cleanup.

## Known limitation

The single-document tool registers as `list_incident_postmortem`, from the API's `ListIncidentPostmortem` operationId. Misleading for a by-id fetch, but tool names come verbatim from operationIds and there is no override mechanism today.

## Testing

855 tests pass. ruff, format, pyright, mypy and bandit clean.

Tools were driven end to end against a stubbed upstream, confirming each resolves to the right path, that the document content is returned, that filters map to the correct query parameters, that no write tool is reachable, and that existing security exclusions still hold. The tool surface goes from 252 to 258 with nothing removed.