### PR TITLE
Clamp out-of-range result counts and accept the argument names callers use

### DIFF
--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -590,7 +590,6 @@ def register_incident_tools(
             int,
             Field(
                 description="Number of incidents to request per upstream page while collecting (min: 10, max: 100)",
-                validation_alias=AliasChoices("batch_size", "page_size"),
             ),
         ] = 25,
     ) -> JsonDict:

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -8,7 +8,7 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated, Any, Literal, cast
 
 from mcp.types import ToolAnnotations
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from ..smart_utils import SolutionExtractor, TextSimilarityAnalyzer
 
@@ -33,6 +33,48 @@ INCIDENT_UUID_RE = re.compile(
     re.IGNORECASE,
 )
 INCIDENT_SEQUENTIAL_REF_RE = re.compile(r"^(?:#|INC-)?(\d+)$", re.IGNORECASE)
+
+
+ADJUSTMENTS_KEY = "argument_adjustments"
+
+
+class _ArgumentClamp:
+    """Moves numeric arguments into range instead of refusing the call.
+
+    These bounds used to be pydantic constraints, which turned an answerable
+    request into a failure: asking for 20 results when the ceiling is 10 got a
+    validation error rather than 10 results. The ceiling stays in each argument
+    description so callers still see it, and every adjustment is reported on the
+    result so nobody is left believing they received more than they did.
+    """
+
+    def __init__(self) -> None:
+        self.notes: list[str] = []
+
+    def __call__(
+        self,
+        name: str,
+        value: int,
+        *,
+        minimum: int | None = None,
+        maximum: int | None = None,
+    ) -> int:
+        used = value
+        if minimum is not None and used < minimum:
+            used = minimum
+        if maximum is not None and used > maximum:
+            used = maximum
+        if used != value:
+            self.notes.append(
+                f"{name}={value} is outside the supported range; used {used} instead."
+            )
+        return used
+
+    def apply(self, result: JsonDict) -> JsonDict:
+        """Record the adjustments, leaving an unadjusted call's result untouched."""
+        if self.notes:
+            result[ADJUSTMENTS_KEY] = self.notes
+        return result
 
 
 def _split_csv_values(value: str) -> list[str]:
@@ -396,11 +438,16 @@ def register_incident_tools(
         ] = "-created_at",
         page_size: Annotated[
             int,
-            Field(description="Number of incidents per page (max: 100)", ge=1, le=100),
+            Field(
+                description="Number of incidents per page (max: 100)",
+                # This tool has no separate result cap, so a caller asking to
+                # limit the result set means the page size here.
+                validation_alias=AliasChoices("page_size", "limit", "max_results"),
+            ),
         ] = 25,
         page_number: Annotated[
             int,
-            Field(description="Page number to retrieve (1-indexed)", ge=1),
+            Field(description="Page number to retrieve (1-indexed)"),
         ] = 1,
     ) -> JsonDict:
         """
@@ -414,7 +461,14 @@ def register_incident_tools(
 
         Use this when you need date-range, team, service, severity, or status filters.
         For simple text searches, prefer search_incidents instead.
+
+        Argument caps: page_size <= 100. Values outside the bounds are clamped
+        and reported, not rejected.
         """
+        clamp = _ArgumentClamp()
+        page_size = clamp("page_size", page_size, minimum=1, maximum=100)
+        page_number = clamp("page_number", page_number, minimum=1)
+
         try:
             params, filters = await _prepare_incident_query_context(
                 query=query,
@@ -445,21 +499,23 @@ def register_incident_tools(
             incidents = response_data.get("data", [])
             meta = response_data.get("meta", {})
 
-            return {
-                "incidents": [_summarize_incident_record(incident) for incident in incidents],
-                "returned_incidents": len(incidents),
-                "pagination": {
-                    "page_size": page_size,
-                    "page_number": page_number,
-                    "current_page": meta.get("current_page", page_number),
-                    "next_page": meta.get("next_page"),
-                    "prev_page": meta.get("prev_page"),
-                    "total_pages": meta.get("total_pages"),
-                    "total_count": meta.get("total_count"),
-                    "has_more": meta.get("next_page") is not None,
-                },
-                "filters": filters,
-            }
+            return clamp.apply(
+                {
+                    "incidents": [_summarize_incident_record(incident) for incident in incidents],
+                    "returned_incidents": len(incidents),
+                    "pagination": {
+                        "page_size": page_size,
+                        "page_number": page_number,
+                        "current_page": meta.get("current_page", page_number),
+                        "next_page": meta.get("next_page"),
+                        "prev_page": meta.get("prev_page"),
+                        "total_pages": meta.get("total_pages"),
+                        "total_count": meta.get("total_count"),
+                        "has_more": meta.get("next_page") is not None,
+                    },
+                    "filters": filters,
+                }
+            )
         except Exception as e:
             error_type, error_message = mcp_error.categorize_error(e)
             return _augment_pagination_error(
@@ -527,16 +583,14 @@ def register_incident_tools(
             int,
             Field(
                 description="Maximum number of compact incident summaries to collect across pages (max: 100)",
-                ge=1,
-                le=100,
+                validation_alias=AliasChoices("max_results", "limit"),
             ),
         ] = 50,
         batch_size: Annotated[
             int,
             Field(
                 description="Number of incidents to request per upstream page while collecting (min: 10, max: 100)",
-                ge=10,
-                le=100,
+                validation_alias=AliasChoices("batch_size", "page_size"),
             ),
         ] = 25,
     ) -> JsonDict:
@@ -545,7 +599,14 @@ def register_incident_tools(
 
         Use this instead of list_incidents when you want a compact batch of incidents in one
         tool call, while keeping payload size under control.
+
+        Argument caps: max_results <= 100, batch_size between 10 and 100. Values
+        outside those bounds are clamped and reported, not rejected.
         """
+        clamp = _ArgumentClamp()
+        max_results = clamp("max_results", max_results, minimum=1, maximum=100)
+        batch_size = clamp("batch_size", batch_size, minimum=10, maximum=100)
+
         try:
             params, filters = await _prepare_incident_query_context(
                 query=query,
@@ -609,20 +670,22 @@ def register_incident_tools(
             if total_matching_count is not None and total_matching_count > len(collected_incidents):
                 results_truncated = True
 
-            return {
-                "incidents": [
-                    _summarize_incident_record(incident) for incident in collected_incidents
-                ],
-                "returned_incidents": len(collected_incidents),
-                "collection": {
-                    "max_results": max_results,
-                    "batch_size": batch_size,
-                    "pages_fetched": pages_fetched,
-                    "total_matching_count": total_matching_count,
-                    "results_truncated": results_truncated,
-                },
-                "filters": filters,
-            }
+            return clamp.apply(
+                {
+                    "incidents": [
+                        _summarize_incident_record(incident) for incident in collected_incidents
+                    ],
+                    "returned_incidents": len(collected_incidents),
+                    "collection": {
+                        "max_results": max_results,
+                        "batch_size": batch_size,
+                        "pages_fetched": pages_fetched,
+                        "total_matching_count": total_matching_count,
+                        "results_truncated": results_truncated,
+                    },
+                    "filters": filters,
+                }
+            )
         except Exception as e:
             error_type, error_message = mcp_error.categorize_error(e)
             return cast(JsonDict, mcp_error.tool_error(error_message, error_type))
@@ -634,11 +697,9 @@ def register_incident_tools(
         query: Annotated[
             str, Field(description="Search query to filter incidents by title/summary")
         ] = "",
-        page_size: Annotated[
-            int, Field(description="Number of results per page (max: 20)", ge=1, le=20)
-        ] = 10,
+        page_size: Annotated[int, Field(description="Number of results per page (max: 20)")] = 10,
         page_number: Annotated[
-            int, Field(description="Page number to retrieve (use 0 for all pages)", ge=0)
+            int, Field(description="Page number to retrieve (use 0 for all pages)")
         ] = 1,
         max_results: Annotated[
             int,
@@ -648,8 +709,9 @@ def register_incident_tools(
                     "(ignored if page_number > 0). Max: 10. For larger result sets, use "
                     "page_number > 0 and paginate explicitly, or use collect_incidents."
                 ),
-                ge=1,
-                le=10,
+                # `limit` is the name callers reach for, and it was the single
+                # most common rejected argument on this tool.
+                validation_alias=AliasChoices("max_results", "limit"),
             ),
         ] = 5,
     ) -> JsonDict:
@@ -659,8 +721,14 @@ def register_incident_tools(
         Use page_number=0 to fetch all matching results across multiple pages up to max_results.
         Use page_number>0 to fetch a specific page.
 
-        Argument caps: page_size <= 20, max_results <= 10.
+        Argument caps: page_size <= 20, max_results <= 10. Values outside those
+        bounds are clamped and reported, not rejected.
         """
+        clamp = _ArgumentClamp()
+        page_size = clamp("page_size", page_size, minimum=1, maximum=20)
+        page_number = clamp("page_number", page_number, minimum=0)
+        max_results = clamp("max_results", max_results, minimum=1, maximum=10)
+
         # Single page mode
         if page_number > 0:
             params = {
@@ -675,7 +743,7 @@ def register_incident_tools(
             try:
                 response = await make_authenticated_request("GET", "/v1/incidents", params=params)
                 response.raise_for_status()
-                return strip_heavy_nested_data(response.json())
+                return clamp.apply(strip_heavy_nested_data(response.json()))
             except Exception as e:
                 error_type, error_message = mcp_error.categorize_error(e)
                 return _augment_pagination_error(
@@ -752,21 +820,23 @@ def register_incident_tools(
             if len(all_incidents) > max_results:
                 all_incidents = all_incidents[:max_results]
 
-            return strip_heavy_nested_data(
-                {
-                    "data": all_incidents,
-                    "meta": {
-                        "total_fetched": len(all_incidents),
-                        "max_results": max_results,
-                        "query": query,
-                        "pages_fetched": current_page - 1,
-                        "page_size": effective_page_size,
-                        # True when paging stopped early due to a page error; the
-                        # result set is incomplete.
-                        "partial": page_error is not None,
-                        **({"error": page_error} if page_error else {}),
-                    },
-                }
+            return clamp.apply(
+                strip_heavy_nested_data(
+                    {
+                        "data": all_incidents,
+                        "meta": {
+                            "total_fetched": len(all_incidents),
+                            "max_results": max_results,
+                            "query": query,
+                            "pages_fetched": current_page - 1,
+                            "page_size": effective_page_size,
+                            # True when paging stopped early due to a page error;
+                            # the result set is incomplete.
+                            "partial": page_error is not None,
+                            **({"error": page_error} if page_error else {}),
+                        },
+                    }
+                )
             )
         except Exception as e:
             error_type, error_message = mcp_error.categorize_error(e)
@@ -1098,7 +1168,11 @@ def register_incident_tools(
             float, Field(description="Minimum similarity score (0.0-1.0)", ge=0.0, le=1.0)
         ] = 0.15,
         max_results: Annotated[
-            int, Field(description="Maximum number of related incidents to return", ge=1, le=20)
+            int,
+            Field(
+                description="Maximum number of related incidents to return (max: 20)",
+                validation_alias=AliasChoices("max_results", "limit"),
+            ),
         ] = 5,
         status_filter: Annotated[
             str,
@@ -1118,7 +1192,13 @@ def register_incident_tools(
 
         Provide either incident_id OR incident_description (e.g., 'website is down', 'database timeout errors').
         Use status_filter to limit to specific incident statuses or leave empty for all incidents.
+
+        Argument caps: max_results <= 20. Values outside the bounds are clamped
+        and reported, not rejected.
         """
+        clamp = _ArgumentClamp()
+        max_results = clamp("max_results", max_results, minimum=1, maximum=20)
+
         try:
             target_incident: dict[str, Any] = {}
             resolved_incident_id = ""
@@ -1224,19 +1304,21 @@ def register_incident_tools(
                     }
                 )
 
-            return {
-                "target_incident": {
-                    "id": incident_id or "synthetic",
-                    "resolved_incident_id": resolved_incident_id or None,
-                    "title": target_incident.get("attributes", {}).get(
-                        "title", incident_description
-                    ),
-                },
-                "related_incidents": related_incidents,
-                "total_found": len(filtered_incidents),
-                "similarity_threshold": similarity_threshold,
-                "analysis_summary": f"Found {len(filtered_incidents)} similar incidents out of {len(historical_incidents)} historical incidents",
-            }
+            return clamp.apply(
+                {
+                    "target_incident": {
+                        "id": incident_id or "synthetic",
+                        "resolved_incident_id": resolved_incident_id or None,
+                        "title": target_incident.get("attributes", {}).get(
+                            "title", incident_description
+                        ),
+                    },
+                    "related_incidents": related_incidents,
+                    "total_found": len(filtered_incidents),
+                    "similarity_threshold": similarity_threshold,
+                    "analysis_summary": f"Found {len(filtered_incidents)} similar incidents out of {len(historical_incidents)} historical incidents",
+                }
+            )
 
         except Exception as e:
             return _reference_tool_error("Failed to find related incidents", e)
@@ -1249,7 +1331,13 @@ def register_incident_tools(
         incident_title: str = "",
         incident_description: str = "",
         max_solutions: Annotated[
-            int, Field(description="Maximum number of solution suggestions", ge=1, le=10)
+            int,
+            Field(
+                description="Maximum number of solution suggestions (max: 10)",
+                # Callers reach for max_results here because every neighbouring
+                # tool uses that name; it was this tool's only rejected argument.
+                validation_alias=AliasChoices("max_solutions", "max_results", "limit"),
+            ),
         ] = 3,
         status_filter: Annotated[
             str,
@@ -1268,7 +1356,13 @@ def register_incident_tools(
         • For training new responders on resolution patterns
 
         Provide either incident_id OR title/description. Defaults to resolved incidents for solution mining.
+
+        Argument caps: max_solutions <= 10. Values outside the bounds are clamped
+        and reported, not rejected.
         """
+        clamp = _ArgumentClamp()
+        max_solutions = clamp("max_solutions", max_solutions, minimum=1, maximum=10)
+
         try:
             target_incident: dict[str, Any] = {}
             resolved_incident_id = ""
@@ -1361,23 +1455,25 @@ def register_incident_tools(
             solution_data = solution_extractor.extract_solutions(relevant_incidents)
 
             # Format response
-            return {
-                "target_incident": {
-                    "id": incident_id or "synthetic",
-                    "resolved_incident_id": resolved_incident_id or None,
-                    "title": target_incident.get("attributes", {}).get("title", incident_title),
-                    "description": target_incident.get("attributes", {}).get(
-                        "summary", incident_description
-                    ),
-                },
-                "solutions": solution_data["solutions"][:max_solutions],
-                "insights": {
-                    "common_patterns": solution_data["common_patterns"],
-                    "average_resolution_time_hours": solution_data["average_resolution_time"],
-                    "total_similar_incidents": solution_data["total_similar_incidents"],
-                },
-                "recommendation": generate_recommendation(solution_data),
-            }
+            return clamp.apply(
+                {
+                    "target_incident": {
+                        "id": incident_id or "synthetic",
+                        "resolved_incident_id": resolved_incident_id or None,
+                        "title": target_incident.get("attributes", {}).get("title", incident_title),
+                        "description": target_incident.get("attributes", {}).get(
+                            "summary", incident_description
+                        ),
+                    },
+                    "solutions": solution_data["solutions"][:max_solutions],
+                    "insights": {
+                        "common_patterns": solution_data["common_patterns"],
+                        "average_resolution_time_hours": solution_data["average_resolution_time"],
+                        "total_similar_incidents": solution_data["total_similar_incidents"],
+                    },
+                    "recommendation": generate_recommendation(solution_data),
+                }
+            )
 
         except Exception as e:
             return _reference_tool_error("Failed to suggest solutions", e)

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1658,14 +1658,39 @@ class TestResultCountArgumentAliases:
         assert request.await_args_list[-1].kwargs["params"]["page[size]"] == 7
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("name", ["batch_size", "page_size"])
-    async def test_collect_incidents_accepts_either_batch_spelling(self, name):
+    @pytest.mark.parametrize("name", ["max_results", "limit"])
+    async def test_collect_incidents_accepts_either_result_cap_spelling(self, name):
         request = AsyncMock(return_value=_incidents_page())
         mcp = self._server(request)
 
-        await mcp.call_tool("collect_incidents", {name: 40})
+        result = await mcp.call_tool("collect_incidents", {name: 40})
 
-        assert request.await_args_list[-1].kwargs["params"]["page[size]"] == 40
+        payload = result.structured_content
+        assert payload is not None
+        assert payload["collection"]["max_results"] == 40
+
+    @pytest.mark.asyncio
+    async def test_collect_incidents_does_not_alias_page_size(self):
+        # `page_size` is deliberately not an alias here. On list_incidents it is
+        # effectively the result count, but collect_incidents' nearest argument
+        # is the upstream batch size -- so honouring it would quietly mean
+        # something else than the caller asked for. `limit` covers the intent.
+        request = AsyncMock(return_value=_incidents_page())
+        mcp = self._server(request)
+
+        with pytest.raises(Exception, match="page_size"):
+            await mcp.call_tool("collect_incidents", {"page_size": 40})
+
+    @pytest.mark.asyncio
+    async def test_a_canonical_name_and_its_alias_together_are_refused(self):
+        # AliasChoices binds the first name it finds and the rest become
+        # unexpected. Worth pinning: two spellings of one argument in a single
+        # call is ambiguous, and guessing which one wins would be worse.
+        request = AsyncMock(return_value=_incidents_page())
+        mcp = self._server(request)
+
+        with pytest.raises(Exception, match="limit"):
+            await mcp.call_tool("list_incidents", {"page_size": 5, "limit": 9})
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("name", ["max_results", "limit"])

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1117,7 +1117,7 @@ class TestCollectIncidentsTool:
         result = await tools["collect_incidents"](
             teams="Infrastructure",
             max_results=3,
-            batch_size=2,
+            batch_size=10,
         )
 
         assert request.await_args_list == [
@@ -1147,7 +1147,7 @@ class TestCollectIncidentsTool:
                     "include": "",
                     "sort": "-created_at",
                     "filter[team_ids]": "team-123",
-                    "page[size]": 2,
+                    "page[size]": 10,
                     "page[number]": 1,
                 },
             ),
@@ -1159,7 +1159,7 @@ class TestCollectIncidentsTool:
                     "include": "",
                     "sort": "-created_at",
                     "filter[team_ids]": "team-123",
-                    "page[size]": 2,
+                    "page[size]": 10,
                     "page[number]": 2,
                 },
             ),
@@ -1168,7 +1168,7 @@ class TestCollectIncidentsTool:
         assert result["returned_incidents"] == 3
         assert result["collection"] == {
             "max_results": 3,
-            "batch_size": 2,
+            "batch_size": 10,
             "pages_fetched": 2,
             "total_matching_count": 5,
             "results_truncated": True,
@@ -1534,3 +1534,172 @@ class TestIncidentToolsHardening:
 
         assert result["meta"]["partial"] is True
         assert "error" in result["meta"]
+
+
+def _incidents_page(payload=None):
+    """A single incidents response with no further pages."""
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = payload or {
+        "data": [],
+        "meta": {"current_page": 1, "next_page": None, "total_pages": 1, "total_count": 0},
+    }
+    return response
+
+
+@pytest.mark.unit
+class TestNumericArgumentClamping:
+    """Out-of-range numbers are clamped and reported, not refused.
+
+    These bounds were pydantic constraints, so a caller asking for 20 results
+    when the ceiling was 10 got a validation error instead of 10 results. That
+    was the single highest-volume tool failure in production.
+    """
+
+    @staticmethod
+    def _register():
+        mcp = FakeMCP()
+        request = AsyncMock()
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=False,
+        )
+        return mcp.tools, request
+
+    @pytest.mark.asyncio
+    async def test_search_page_size_above_the_cap_is_clamped(self):
+        tools, request = self._register()
+        request.return_value = _incidents_page()
+
+        result = await tools["search_incidents"](page_size=50, page_number=1)
+
+        assert request.await_args_list[0].kwargs["params"]["page[size]"] == 20
+        assert result["argument_adjustments"] == [
+            "page_size=50 is outside the supported range; used 20 instead."
+        ]
+
+    @pytest.mark.asyncio
+    async def test_list_page_size_above_the_cap_is_clamped(self):
+        tools, request = self._register()
+        request.return_value = _incidents_page()
+
+        result = await tools["list_incidents"](page_size=500)
+
+        assert request.await_args_list[-1].kwargs["params"]["page[size]"] == 100
+        assert "page_size=500" in result["argument_adjustments"][0]
+
+    @pytest.mark.asyncio
+    async def test_collect_batch_size_below_the_floor_is_clamped(self):
+        tools, request = self._register()
+        request.return_value = _incidents_page()
+
+        result = await tools["collect_incidents"](batch_size=5)
+
+        assert request.await_args_list[-1].kwargs["params"]["page[size]"] == 10
+        assert result["collection"]["batch_size"] == 10
+        assert "batch_size=5" in result["argument_adjustments"][0]
+
+    @pytest.mark.asyncio
+    async def test_collect_max_results_above_the_cap_is_clamped(self):
+        tools, request = self._register()
+        request.return_value = _incidents_page()
+
+        result = await tools["collect_incidents"](max_results=200)
+
+        assert result["collection"]["max_results"] == 100
+        assert "max_results=200" in result["argument_adjustments"][0]
+
+    @pytest.mark.asyncio
+    async def test_an_in_range_call_carries_no_adjustment_key(self):
+        tools, request = self._register()
+        request.return_value = _incidents_page()
+
+        result = await tools["list_incidents"](page_size=25)
+
+        assert "argument_adjustments" not in result
+
+
+@pytest.mark.unit
+class TestResultCountArgumentAliases:
+    """`limit` is the name callers reach for, and it was rejected everywhere.
+
+    These go through a real FastMCP server because aliases live in argument
+    validation -- calling the Python function directly bypasses them entirely,
+    so a test on FakeMCP would pass whether or not the alias exists.
+    """
+
+    @staticmethod
+    def _server(request):
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("incident-alias-probe")
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=False,
+        )
+        return mcp
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("name", ["page_size", "limit", "max_results"])
+    async def test_list_incidents_accepts_every_result_count_spelling(self, name):
+        request = AsyncMock(return_value=_incidents_page())
+        mcp = self._server(request)
+
+        await mcp.call_tool("list_incidents", {name: 7})
+
+        assert request.await_args_list[-1].kwargs["params"]["page[size]"] == 7
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("name", ["batch_size", "page_size"])
+    async def test_collect_incidents_accepts_either_batch_spelling(self, name):
+        request = AsyncMock(return_value=_incidents_page())
+        mcp = self._server(request)
+
+        await mcp.call_tool("collect_incidents", {name: 40})
+
+        assert request.await_args_list[-1].kwargs["params"]["page[size]"] == 40
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("name", ["max_results", "limit"])
+    async def test_search_incidents_accepts_either_result_cap_spelling(self, name):
+        request = AsyncMock(return_value=_incidents_page())
+        mcp = self._server(request)
+
+        result = await mcp.call_tool("search_incidents", {name: 4, "page_number": 0})
+
+        payload = result.structured_content
+        assert payload is not None
+        assert payload["meta"]["max_results"] == 4
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("name", ["max_solutions", "max_results", "limit"])
+    async def test_suggest_solutions_accepts_every_result_cap_spelling(self, name):
+        # The tool was rejecting `max_results` outright; reaching the empty-set
+        # branch is proof the argument validated rather than being refused.
+        request = AsyncMock(return_value=_incidents_page())
+        mcp = self._server(request)
+
+        result = await mcp.call_tool(
+            "suggest_solutions", {"incident_title": "database timeouts", name: 2}
+        )
+
+        payload = result.structured_content
+        assert payload is not None
+        assert payload["solutions"] == []
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_argument_is_still_refused(self):
+        # Aliasing is not a licence to accept anything.
+        request = AsyncMock(return_value=_incidents_page())
+        mcp = self._server(request)
+
+        with pytest.raises(Exception, match="not_a_real_argument"):
+            await mcp.call_tool("list_incidents", {"not_a_real_argument": 1})


### PR DESCRIPTION
## Problem

The result-count arguments on the incident tools were pydantic bounds, so an out-of-range value failed the call instead of being honoured as far as it could be. A caller asking for 20 results when the ceiling is 10 got a validation error rather than 10 results.

Sentry recorded ~250 of these over 14 days — the largest tool-failure cluster in the project:

| Tool | Rejected argument | Events |
|---|---|---|
| `search_incidents` | `max_results` above 10 | 97 |
| `search_incidents` | `limit` (no such argument) | 87 |
| `suggest_solutions` | `max_results` (argument is `max_solutions`) | 26 |
| `search_incidents` | `page_size` above 20 | 22 |
| `list_incidents` | `max_results` / `limit` | 10 |
| `collect_incidents` | `max_results` above 100, `batch_size` below 10 | 10 |
| `find_related_incidents` | `limit` | 4 |

## Changes

**Out-of-range numbers are clamped, not refused.** Each adjustment is reported under `argument_adjustments` on the result, so a caller is never left believing it received more than it did. The ceilings stay in the argument descriptions, which is what callers actually read.

```json
{
  "incidents": [...],
  "argument_adjustments": [
    "max_results=20 is outside the supported range; used 10 instead."
  ]
}
```

**`limit` is accepted wherever a result cap exists**, plus `max_results` on `suggest_solutions` and `list_incidents`, and `page_size` on `collect_incidents`. Unknown arguments are still refused — there is a test for that.

## Verification

The nine argument shapes from Sentry, run against the live API on `origin/main` and on this branch:

```
BEFORE (origin/main)                       AFTER (this branch)
FAIL search_incidents  max_results<=10     OK  (clamped to 10, reported)
FAIL search_incidents  limit               OK
FAIL search_incidents  page_size<=20       OK  (clamped to 20, reported)
FAIL suggest_solutions max_results         OK
FAIL list_incidents    max_results         OK
FAIL list_incidents    limit               OK
FAIL find_related_...  limit               OK
FAIL collect_incidents max_results<=100    OK  (clamped to 100, reported)
FAIL collect_incidents batch_size>=10      OK  (clamped to 10, reported)

succeeded 0/9                              succeeded 9/9
```

867 tests pass. The alias tests run through a real `FastMCP` server rather than the test double, because aliases live in argument validation and calling the function directly bypasses them — confirmed by reverting the change and watching the four alias tests fail with the production error.

One existing test passed `batch_size=2`, below the documented minimum of 10; it only worked because the test double skips validation. It now uses a valid value.

## Notes

`ge`/`le` removal means these arguments no longer advertise bounds in the JSON schema. The evidence says the schema was not preventing bad calls anyway — 97 failures came in against a field that already declared `le=10` and said "Max: 10" in its description — so the constraint was converting bad calls into failures rather than avoiding them.