### PR TITLE
Let create_incident forward an Idempotency-Key header

### DIFF
--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -90,6 +90,32 @@ def _normalize_optional_text(value: str | None) -> str | None:
     return normalized or None
 
 
+IDEMPOTENCY_KEY_MAX_LENGTH = 255
+
+
+def _validate_idempotency_key(value: str) -> str:
+    """Return a key that is safe to send as a header value, or raise ValueError.
+
+    This value arrives from a model and goes straight into an HTTP header.
+    httpx accepts CR, LF and NUL inside a header value when the request is
+    constructed, so nothing further down the stack reliably stops a crafted key
+    from attempting header injection -- this is the boundary that has to.
+    """
+    key = value.strip()
+    if not key:
+        raise ValueError("idempotency_key was provided but is empty")
+    if len(key) > IDEMPOTENCY_KEY_MAX_LENGTH:
+        raise ValueError(
+            f"idempotency_key must be at most {IDEMPOTENCY_KEY_MAX_LENGTH} characters "
+            f"(got {len(key)})"
+        )
+    if not key.isascii():
+        raise ValueError("idempotency_key must contain only ASCII characters")
+    if any(character < " " or character == "\x7f" for character in key):
+        raise ValueError("idempotency_key must not contain control characters")
+    return key
+
+
 def _extract_incident_severity(severity_value: Any) -> str | None:
     """Normalize severity values from Rootly API responses into a compact string."""
     if severity_value is None:
@@ -1012,8 +1038,25 @@ def register_incident_tools(
                 str | None,
                 Field(description="Comma-separated incident type IDs to attach to the incident."),
             ] = None,
+            idempotency_key: Annotated[
+                str | None,
+                Field(
+                    description=(
+                        "Optional key forwarded to the Rootly API as the Idempotency-Key "
+                        "header, so that retrying a call with the same key does not create a "
+                        "second incident. Reuse the same key across retries of one logical "
+                        "declaration, and use a fresh key for a genuinely new incident. "
+                        "Max 255 ASCII characters."
+                    )
+                ),
+            ] = None,
         ) -> JsonDict:
-            """Create an incident with a scoped set of fields for agent-driven workflows."""
+            """Create an incident with a scoped set of fields for agent-driven workflows.
+
+            Supply idempotency_key when a retry must not be able to create a duplicate;
+            it is passed through to the API, which decides whether a repeated key
+            replays the original response.
+            """
             normalized_title = _normalize_optional_text(title)
             normalized_summary = _normalize_optional_text(summary)
 
@@ -1057,8 +1100,20 @@ def register_incident_tools(
                 }
             }
 
+            # Only send the header when a key was supplied, so a call without one
+            # is byte-for-byte the request this tool has always made.
+            request_kwargs: dict[str, Any] = {"json": payload}
+            if idempotency_key is not None:
+                try:
+                    validated_key = _validate_idempotency_key(idempotency_key)
+                except ValueError as exc:
+                    return cast(JsonDict, mcp_error.tool_error(str(exc), "validation_error"))
+                request_kwargs["headers"] = {"Idempotency-Key": validated_key}
+
             try:
-                response = await make_authenticated_request("POST", "/v1/incidents", json=payload)
+                response = await make_authenticated_request(
+                    "POST", "/v1/incidents", **request_kwargs
+                )
                 response.raise_for_status()
 
                 response_data = response.json()

--- a/tests/unit/test_authentication.py
+++ b/tests/unit/test_authentication.py
@@ -287,3 +287,66 @@ class TestParameterTransformation:
         result = client._transform_params({})
 
         assert result == {}
+
+
+@pytest.mark.unit
+class TestCustomHeaderForwarding:
+    """A per-request header must reach the wire alongside the managed ones.
+
+    `request()` rebuilds the header dict on every call and a request event hook
+    overwrites content-type and accept, so "the tool passes headers=" is not on
+    its own evidence that the header is actually sent. create_incident's
+    Idempotency-Key support depends on this.
+    """
+
+    @staticmethod
+    def _client_recording_requests(seen, *, hosted=False):
+        import httpx
+
+        client = AuthenticatedHTTPXClient(hosted=hosted)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(dict(request.headers))
+            return httpx.Response(201, json={"data": {}})
+
+        client.client = httpx.AsyncClient(
+            base_url="https://api.rootly.com",
+            headers=dict(client.client.headers),
+            transport=httpx.MockTransport(handler),
+            event_hooks={"request": [client._enforce_jsonapi_headers]},
+        )
+        return client
+
+    @pytest.mark.asyncio
+    async def test_a_custom_header_reaches_the_wire(self, mock_environment_token):
+        seen: list[dict] = []
+        client = self._client_recording_requests(seen)
+
+        await client.request(
+            "POST", "/v1/incidents", json={}, headers={"Idempotency-Key": "decl-001"}
+        )
+
+        assert seen[0]["idempotency-key"] == "decl-001"
+
+    @pytest.mark.asyncio
+    async def test_it_does_not_displace_the_managed_headers(self, mock_environment_token):
+        seen: list[dict] = []
+        client = self._client_recording_requests(seen)
+
+        await client.request(
+            "POST", "/v1/incidents", json={}, headers={"Idempotency-Key": "decl-001"}
+        )
+
+        sent = seen[0]
+        assert sent["authorization"] == f"Bearer {mock_environment_token}"
+        assert sent["content-type"] == "application/vnd.api+json"
+        assert sent["accept"] == "application/vnd.api+json"
+
+    @pytest.mark.asyncio
+    async def test_no_custom_header_means_none_is_sent(self, mock_environment_token):
+        seen: list[dict] = []
+        client = self._client_recording_requests(seen)
+
+        await client.request("POST", "/v1/incidents", json={})
+
+        assert "idempotency-key" not in seen[0]

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1728,3 +1728,212 @@ class TestResultCountArgumentAliases:
 
         with pytest.raises(Exception, match="not_a_real_argument"):
             await mcp.call_tool("list_incidents", {"not_a_real_argument": 1})
+
+
+def _last_call(request):
+    """The most recent call to a request mock, asserted to exist.
+
+    `await_args` is Optional, and a test that reads it after no call was made
+    should say so rather than fail on an attribute of None.
+    """
+    call_args = request.await_args
+    assert call_args is not None, "expected a request to have been made"
+    return call_args
+
+
+@pytest.mark.unit
+class TestCreateIncidentIdempotencyKey:
+    """create_incident can forward an Idempotency-Key header.
+
+    The Rootly API documents this header for incident creation, but the tool
+    exposed no argument that could carry it, so a caller that needed retry
+    safety had no way to get one.
+    """
+
+    @staticmethod
+    def _register():
+        mcp = FakeMCP()
+        request = AsyncMock()
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=True,
+        )
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "data": {"id": "inc-1", "type": "incidents", "attributes": {"title": "Boom"}}
+        }
+        request.return_value = response
+        return mcp.tools, request
+
+    @pytest.mark.asyncio
+    async def test_the_key_is_sent_as_the_header(self):
+        tools, request = self._register()
+
+        await tools["create_incident"](title="Boom", idempotency_key="decl-2026-08-05-001")
+
+        assert _last_call(request).kwargs["headers"] == {"Idempotency-Key": "decl-2026-08-05-001"}
+
+    @pytest.mark.asyncio
+    async def test_without_a_key_the_request_is_unchanged(self):
+        # The regression that matters: every existing caller must produce exactly
+        # the request this tool made before the argument existed.
+        tools, request = self._register()
+
+        await tools["create_incident"](title="Boom")
+
+        assert "headers" not in _last_call(request).kwargs
+        assert set(_last_call(request).kwargs) == {"json"}
+        assert _last_call(request).args == ("POST", "/v1/incidents")
+
+    @pytest.mark.asyncio
+    async def test_surrounding_whitespace_is_trimmed(self):
+        tools, request = self._register()
+
+        await tools["create_incident"](title="Boom", idempotency_key="  key-1  ")
+
+        assert _last_call(request).kwargs["headers"] == {"Idempotency-Key": "key-1"}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "key",
+        ["a\r\nX-Evil: 1", "a\nX-Evil: 1", "a\rX-Evil: 1", "a\x00b", "a\x7fb"],
+        ids=["crlf", "lf", "cr", "nul", "del"],
+    )
+    async def test_a_key_that_could_forge_a_header_is_refused(self, key):
+        # httpx accepts these inside a header value when the request is built,
+        # so rejecting them here is what actually prevents the injection.
+        tools, request = self._register()
+
+        result = await tools["create_incident"](title="Boom", idempotency_key=key)
+
+        assert result["error"] is True
+        assert result["error_type"] == "validation_error"
+        assert "control characters" in result["message"]
+        assert request.await_count == 0, "no request may be sent for a rejected key"
+
+    @pytest.mark.asyncio
+    async def test_a_non_ascii_key_is_refused(self):
+        # httpx raises UnicodeEncodeError on these; a validation error is clearer.
+        tools, request = self._register()
+
+        result = await tools["create_incident"](title="Boom", idempotency_key="clé-1")
+
+        assert result["error_type"] == "validation_error"
+        assert "ASCII" in result["message"]
+        assert request.await_count == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("key", ["", "   "], ids=["empty", "whitespace"])
+    async def test_an_empty_key_is_refused_rather_than_ignored(self, key):
+        # Passing the argument signals intent to be retry-safe. Treating a blank
+        # value as "no key" would leave the caller believing it was protected.
+        tools, request = self._register()
+
+        result = await tools["create_incident"](title="Boom", idempotency_key=key)
+
+        assert result["error_type"] == "validation_error"
+        assert "empty" in result["message"]
+        assert request.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_an_over_long_key_is_refused(self):
+        tools, request = self._register()
+
+        result = await tools["create_incident"](title="Boom", idempotency_key="x" * 256)
+
+        assert result["error_type"] == "validation_error"
+        assert "255" in result["message"]
+        assert request.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_a_key_at_the_length_limit_is_accepted(self):
+        tools, request = self._register()
+
+        await tools["create_incident"](title="Boom", idempotency_key="x" * 255)
+
+        assert _last_call(request).kwargs["headers"] == {"Idempotency-Key": "x" * 255}
+
+    @pytest.mark.asyncio
+    async def test_the_missing_title_check_still_runs_first(self):
+        # Preserves the error a caller already gets today when both are wrong.
+        tools, request = self._register()
+
+        result = await tools["create_incident"](title="  ", idempotency_key="a\r\nb")
+
+        assert "at least one of title or summary" in result["message"]
+        assert request.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_the_payload_is_untouched_by_the_key(self):
+        tools, request = self._register()
+
+        await tools["create_incident"](title="Boom", severity_id="sev-1", idempotency_key="key-1")
+
+        assert _last_call(request).kwargs["json"] == {
+            "data": {
+                "type": "incidents",
+                "attributes": {"title": "Boom", "severity_id": "sev-1"},
+            }
+        }
+
+
+@pytest.mark.unit
+class TestCreateIncidentPublishedSchema:
+    """The argument has to appear in the schema clients read, not just in Python.
+
+    A caller integrating against the hosted endpoint discovers arguments from
+    tools/list, so an argument that works but is not advertised does not solve
+    their problem.
+    """
+
+    @staticmethod
+    async def _create_incident_schema():
+        from fastmcp import FastMCP
+
+        mcp = FastMCP("schema-probe")
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=AsyncMock(),
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=True,
+        )
+        tool = await mcp.get_tool("create_incident")
+        assert tool is not None
+        return tool.parameters
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_is_advertised(self):
+        schema = await self._create_incident_schema()
+
+        assert "idempotency_key" in schema["properties"]
+
+    @pytest.mark.asyncio
+    async def test_it_is_optional_and_documented(self):
+        schema = await self._create_incident_schema()
+        field = schema["properties"]["idempotency_key"]
+
+        assert "idempotency_key" not in schema.get("required", [])
+        assert field.get("default") is None
+        assert "Idempotency-Key" in field["description"]
+
+    @pytest.mark.asyncio
+    async def test_the_existing_arguments_are_untouched(self):
+        schema = await self._create_incident_schema()
+
+        assert set(schema["properties"]) == {
+            "title",
+            "summary",
+            "severity_id",
+            "service_ids",
+            "team_ids",
+            "environment_ids",
+            "incident_type_ids",
+            "idempotency_key",
+        }


### PR DESCRIPTION
Draft: the code is complete and tested, but the API does not implement the header yet. See "Why this is a draft" below.

## Problem

The Rootly API documentation recommends sending `Idempotency-Key` when creating an incident, but `create_incident` exposes no argument that could carry one. A customer running an unattended agent hit this and chose to block incident declaration rather than risk duplicates on retry.

## Change

Adds an optional `idempotency_key` argument to `create_incident`, forwarded as the `Idempotency-Key` header on the create request.

When the argument is omitted, the outgoing request is byte-for-byte the one this tool has always made. That is the property most of the new tests pin, and it is why this is safe to merge whenever the API side is ready.

The key is validated before it becomes a header value. This matters more than it looks:

```
httpx.Request("POST", url, headers={"Idempotency-Key": "abc\r\nX-Evil: 1"})
  -> ACCEPTED, value stored verbatim
```

httpx accepts CR, LF and NUL inside a header value at construction time, so the tool boundary is what has to reject them. Over-length (>255), non-ASCII and empty values are refused too, and nothing is sent upstream when a key is rejected.

No transport changes were needed. `AuthenticatedHTTPXClient.request` rebuilds the header dict per call and an event hook overwrites content-type and accept, so a test was added proving a custom header actually survives to the wire alongside `Authorization`.

## Why this is a draft

The API ignores the header. Ten requests across five variants produced ten separate incidents:

| Variant | Result |
|---|---|
| `Idempotency-Key`, UUID key, identical payload | 2 incidents |
| `Idempotency-Key`, opaque key | 2 incidents |
| `X-Idempotency-Key` | 2 incidents |
| `Idempotency_Key` | 2 incidents |
| Same key, different title | 2 incidents |

No idempotency-related response headers on any of the ten. All twelve test incidents were cancelled.

Confirmed at source: nothing in `rootlyhq/rootly` reads an `Idempotency-Key` header, and both create paths (`create_with_service` and `create_legacy`) save unconditionally. `rootly_openapi.json` contains zero occurrences of "idempotency".

Merging this before the API implements the header would let a caller believe a retry is safe when it is not, which is worse than the current state where they know it is not available. Two follow-ups are needed first:

1. `rootlyhq/rootly` implements the header on `POST /v1/incidents`. The race-safe pattern already exists in `Ai::Sre::Investigation.start!`, and `alerts`/`pulses` already carry a `webhook_idempotency_key` column with a unique index.
2. `rootlyhq/rootly-docs` corrects `incidents/creating-incidents/creating-incidents-via-api.mdx`, which recommends the header in two places.

## Decisions worth reviewing

`idempotentHint` stays `false`. The annotation is static and the tool is only idempotent when a caller supplies a key, so claiming otherwise would misdescribe the default path.

No key is generated when one is absent. Doing so would change behaviour for every existing caller and could suppress genuinely distinct incidents.

An empty or whitespace-only key is refused rather than treated as absent. Passing the argument signals intent to be retry-safe, so silently ignoring a blank value would leave a caller believing it was protected.

## Tests

872 pass, up from 851. New coverage: the header is sent; no header when no key; whitespace trimmed; CR/LF/CRLF/NUL/DEL refused with no request made; non-ASCII, empty and over-length refused; 255 accepted and 256 refused; existing title/summary validation still runs first; the payload is unchanged by the key; the argument appears in the published schema and the other seven are untouched; and a custom header survives the real client to the wire.

Verified the tests fail without the change: removing only the forwarding line, so the argument is accepted and silently ignored, fails three of them.