### PR TITLE
Release 2.3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Rootly MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.18] - Released 2026-08-29
+
+### Fixed
+
+- **Shift date ranges are split at the spans the API actually accepts**: the chunking thresholds were set to 62 and 31 days, which are the first values `/v1/shifts` and `/v1/schedules/{id}/shifts` reject, so a long range was never split and the request failed. The caps are now 60 and 30 days. Long ranges are also split for `get_schedule_shifts` and for the shift metrics tools, which previously did not chunk at all.
+- **A failed shift page is no longer reported as zero shifts**: a page that errored mid-scan was silently dropped, so a partial result looked like an empty schedule. Truncated results now say so, and a page that fails before answering is retried rather than abandoned.
+- **A shift date range that cannot be used is rejected up front** instead of being sent and failing upstream, and `/v1/shifts` requests beyond the horizon where shifts have been generated now say so rather than returning an unexplained empty list.
+- **Result-count arguments no longer fail a call that can be answered**: `max_results`, `page_size` and `batch_size` were validated as hard bounds, so asking for 20 results when the ceiling is 10 returned a validation error instead of 10 results. This was the highest-volume tool failure in production. Values outside the supported range are now clamped, and every adjustment is reported under `argument_adjustments` on the result so a caller is never told it received more than it did.
+
+### Changed
+
+- **The result-count arguments accept the names callers reach for**: `limit` is accepted wherever a result cap exists, along with `max_results` on `suggest_solutions` and `list_incidents`. Unknown arguments are still refused.
+- **Shift date ranges are named the way the rest of the on-call tools name them** (`start_date`/`end_date`), with the previous `from`/`to` and `from_date`/`to_date` spellings still accepted.
+
 ## [2.3.17] - Released 2026-08-10
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rootly-mcp-server"
-version = "2.3.17"
+version = "2.3.18"
 description = "Secure Model Context Protocol server for Rootly APIs with AI SRE capabilities, comprehensive error handling, and input validation"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1789,7 +1789,7 @@ wheels = [
 
 [[package]]
 name = "rootly-mcp-server"
-version = "2.3.17"
+version = "2.3.18"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Version bump and changelog for what has merged since 2.3.17: #182 and #188. #187 is still open and is not included.

Bumped in `pyproject.toml`, `uv.lock` (regenerated with `uv lock`, one line changed) and `CHANGELOG.md`. `__version__` reads from package metadata, so no source change is needed; verified it resolves to 2.3.18.

## Included

**#182 — shift date ranges.** The chunking thresholds were 62 and 31 days, which are the first values the two shift endpoints reject, so a long range was never split and the request simply failed. Now 60 and 30. Chunking was also extended to `get_schedule_shifts` and the shift metrics tools, a failed page is no longer reported as zero shifts, and an unusable range is rejected before the request goes out.

**#188 — result-count arguments.** Hard bounds turned an answerable request into a failure: asking for 20 results when the ceiling is 10 returned a validation error rather than 10 results. Values are now clamped and every adjustment is reported under `argument_adjustments`. `limit` is accepted wherever a result cap exists. Verified in production after deploy.

## Checks

869 tests pass. ruff check and format, pyright, and mypy are clean. `uv build` produces both artifacts at 2.3.18, and `data/swagger.json` is still bundled in the wheel — that was the 2.3.17 packaging fix and worth confirming on every release.