### PR TITLE
ci: add HOL plugin security scan

### DIFF
--- a/.github/workflows/plugin-security-scan.yml
+++ b/.github/workflows/plugin-security-scan.yml
@@ -1,0 +1,28 @@
+name: Plugin Security Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: HOL Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Scan plugin
+        uses: hashgraph-online/ai-plugin-scanner-action@55616c962cf86368423f7673b2ecdfdbe613d1af # v1.2.515
+        with:
+          plugin_dir: "."
+          config: ".plugin-scanner.toml"
+          min_score: "80"
+          fail_on_severity: high

--- a/.gitignore
+++ b/.gitignore
@@ -193,10 +193,11 @@ swagger.json
 test_output/
 *.tmp
 
-# Markdown files (exclude all except README and CONTRIBUTING)
+# Markdown files (exclude all except project documentation)
 *.md
 !README.md
 !CONTRIBUTING.md
 !CHANGELOG.md
+!SECURITY.md
 .beads/
 .claude/

--- a/.plugin-scanner.toml
+++ b/.plugin-scanner.toml
@@ -1,0 +1,16 @@
+[scanner]
+# These files contain reviewed test credentials, documentation placeholders,
+# environment-variable names, or CI secret references. Keep this list
+# path-specific so hardcoded-secret detection remains enabled everywhere else.
+ignore_paths = [
+  "Makefile",
+  ".github/workflows/ci.yml",
+  "src/rootly_mcp_server/__main__.py",
+  "src/rootly_mcp_server/server_defaults.py",
+  "tests/conftest.py",
+  "tests/integration/remote/test_essential.py",
+  "tests/unit/test_authentication.py",
+  "tests/unit/test_och_client.py",
+  "tests/unit/test_security.py",
+  "tests/unit/test_telemetry_scrubber.py",
+]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,21 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest released version of Rootly MCP Server
+and the current `main` branch. Please reproduce a suspected vulnerability
+against the latest version before reporting it when possible.
+
+## Reporting a Vulnerability
+
+Do not report security vulnerabilities through public GitHub issues.
+
+Email [security@rootly.com](mailto:security@rootly.com) with:
+
+- a description of the vulnerability and its potential impact;
+- the affected version, commit, or deployment mode;
+- clear reproduction steps or a proof of concept; and
+- any suggested remediation, if available.
+
+Follow Rootly's [Vulnerability Disclosure Policy](https://rootly.com/legal/vulnerability-disclosure-policy)
+for reporting guidelines and safe-harbor terms.


### PR DESCRIPTION
## Summary

- add the HOL plugin security scanner on pushes to `main` and pull requests
- pin both GitHub Actions dependencies to immutable 40-character commit SHAs
- keep the scanner gate at score 80 with failures on high-severity findings
- suppress the ten reviewed false-positive files through path-scoped scanner configuration while leaving secret detection enabled everywhere else
- add `SECURITY.md` with Rootly’s verified security reporting contact and disclosure policy

## Verification

- `plugin-scanner` v2.0.1116: 100/100 (A), zero findings
- scanner policy and runtime verification passed
- workflow YAML parses successfully
- `git diff --check` passes