### PR TITLE
chore: bump agentcat to 2.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN uv pip install --system --no-cache-dir -e .
 # fit for our stateless hosted transport. Our integration code is unchanged.
 # In case AgentCat constrains Pydantic, we restore the server's pinned version
 # after installation.
-RUN uv pip install --system --no-cache-dir "agentcat[community]==2.0.2" \
+RUN uv pip install --system --no-cache-dir "agentcat[community]==2.1.0" \
     && uv pip install --system --no-cache-dir pydantic==2.13.4
 
 # Create non-root user


### PR DESCRIPTION
Bumps the AgentCat (hosted telemetry) pin in the Dockerfile from `1.0.1` → `2.1.0`.

## What's new in v2.1.0
- Relaxed the language behind session ID (less demanding).
- Instruction text is emitted only on the first response, not every response.
- Session ID is now **prepended** with a low footprint to avoid truncation — this server's large responses previously exposed a flaw where agents truncated the appended session ID.

## Safety
- **Telemetry-only and lazily imported.** AgentCat is installed only in the container and loaded via `importlib` in `maybe_enable_mcpcat_tracking`; it's not part of the repo dependency graph.
- **Public API unchanged in 2.x.** Verified on PyPI that `agentcat.track(server, project_id, options)`, `AgentCatOptions(identify=...)`, and `agentcat.types.UserIdentity` still exist. The v2 breaking change is the internal stateless/`session_id` model (the MCP 2026-07-28 stateless update) — not the surface this repo uses.
- **Graceful degradation.** `maybe_enable_mcpcat_tracking` wraps `track()` in try/except and logs-and-skips on any failure, so even an unexpected SDK shift can't break the server.
- The post-install `pydantic==2.13.4` re-pin is unchanged.
- CI Container Tests build the image and will validate the `agentcat[community]==2.1.0` install resolves.

## Deploy note
Per the AgentCat maintainer: some agents don't refresh their tool list mid-session, so there may be a brief delay before an agent picks up the new deploy. Consider deploying in a low-activity window to minimize impact.

No customer/runtime impact.