### PR TITLE
Complete the annotations on the tool AgentCat injects

### DIFF
--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -11,6 +11,7 @@ import logging
 import os
 import time
 import traceback
+from collections.abc import Sequence
 from typing import Any
 
 import fastmcp.server.middleware as fastmcp_middleware
@@ -499,6 +500,44 @@ class ArgumentNormalizationMiddleware(fastmcp_middleware.Middleware):
         return await call_next(context)
 
 
+# Tools registered by the telemetry SDK rather than by us, with the annotations
+# they should carry. AgentCat 2.1.0 registers `get_more_tools` with only
+# `{"readOnlyHint": True}` (adapters/community.py), so `destructiveHint` and
+# `openWorldHint` fall back to the spec defaults -- both `true`, describing the
+# tool as destructive and open-world. It is neither: its handler returns a fixed
+# string and never reaches the API. Reported upstream; remove this once the SDK
+# sets them itself.
+_INJECTED_TOOL_ANNOTATIONS: dict[str, mt.ToolAnnotations] = {
+    "get_more_tools": mt.ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        openWorldHint=False,
+    ),
+}
+
+
+class InjectedToolAnnotationMiddleware(fastmcp_middleware.Middleware):
+    """Completes safety annotations on tools this server did not register.
+
+    An injected tool cannot be annotated where it is defined, and unset hints do
+    not read as "unknown" -- the MCP spec defaults them to the cautious answer.
+    A client that respects annotations may therefore prompt before every call,
+    and annotation scanners flag the tool.
+    """
+
+    async def on_list_tools(
+        self,
+        context: fastmcp_middleware.MiddlewareContext[mt.ListToolsRequest],
+        call_next: fastmcp_middleware.CallNext[mt.ListToolsRequest, Sequence[Any]],
+    ) -> Sequence[Any]:
+        tools = await call_next(context)
+        for tool in tools:
+            annotations = _INJECTED_TOOL_ANNOTATIONS.get(getattr(tool, "name", ""))
+            if annotations is not None:
+                tool.annotations = annotations
+        return tools
+
+
 class ToolUsageLoggingMiddleware(fastmcp_middleware.Middleware):
     """FastMCP middleware that logs per-tool usage with caller identity context."""
 
@@ -709,6 +748,7 @@ def create_rootly_mcp_server(
     # to snake_case before usage logging records the (canonical) tool name.
     mcp.add_middleware(CamelCaseAliasMiddleware(camel_to_snake_aliases))
     mcp.add_middleware(ArgumentNormalizationMiddleware())
+    mcp.add_middleware(InjectedToolAnnotationMiddleware())
     mcp.add_middleware(ToolUsageLoggingMiddleware())
 
     @mcp.custom_route("/healthz", methods=["GET"])

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1714,3 +1714,69 @@ class TestApplyAnnotationsToAutogenTools:
         assert tools["list_items"].annotations.readOnlyHint is True
         assert tools["create_item"].annotations.readOnlyHint is False
         assert tools["delete_item"].annotations.destructiveHint is True
+
+
+@pytest.mark.unit
+class TestInjectedToolAnnotations:
+    """The telemetry SDK registers `get_more_tools` with only readOnlyHint.
+
+    Unset hints are not "unknown" -- the MCP spec defaults destructiveHint and
+    openWorldHint to true, so the tool advertises itself as destructive and
+    open-world. It is neither. We cannot annotate a tool we did not register, so
+    the listing is completed on the way out.
+    """
+
+    @staticmethod
+    async def _list_through_middleware(tools):
+        from typing import Any, cast
+
+        from rootly_mcp_server.server import InjectedToolAnnotationMiddleware
+
+        async def call_next(context):
+            return tools
+
+        # The hook reads nothing off the context, so a placeholder is enough to
+        # exercise it without building a full MiddlewareContext.
+        return await InjectedToolAnnotationMiddleware().on_list_tools(cast(Any, None), call_next)
+
+    @pytest.mark.asyncio
+    async def test_completes_the_injected_tools_annotations(self):
+        injected = SimpleNamespace(
+            name="get_more_tools",
+            annotations=mt.ToolAnnotations(readOnlyHint=True),
+        )
+
+        result = await self._list_through_middleware([injected])
+
+        ann = result[0].annotations
+        assert ann.readOnlyHint is True
+        assert ann.destructiveHint is False
+        assert ann.openWorldHint is False
+
+    @pytest.mark.asyncio
+    async def test_leaves_our_own_tools_alone(self):
+        ours = SimpleNamespace(
+            name="list_incidents",
+            annotations=mt.ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        )
+
+        result = await self._list_through_middleware([ours])
+
+        assert result[0].annotations.openWorldHint is True
+        assert result[0].annotations.destructiveHint is None
+
+    @pytest.mark.asyncio
+    async def test_a_tool_with_no_annotations_is_untouched(self):
+        bare = SimpleNamespace(name="something_else", annotations=None)
+
+        result = await self._list_through_middleware([bare])
+
+        assert result[0].annotations is None
+
+    @pytest.mark.asyncio
+    async def test_the_injected_tool_is_still_named_get_more_tools(self):
+        # Keyed by name: if the SDK renames the tool this patch silently stops
+        # applying, so pin the name we are compensating for.
+        from rootly_mcp_server.server import _INJECTED_TOOL_ANNOTATIONS
+
+        assert "get_more_tools" in _INJECTED_TOOL_ANNOTATIONS


### PR DESCRIPTION
## Problem

AgentCat registers a `get_more_tools` tool into every server it tracks, annotated with only `readOnlyHint`:

```python
# agentcat 2.1.0, src/agentcat/modules/adapters/community.py:860
annotations: Any = {"readOnlyHint": True}
```

`destructiveHint` and `openWorldHint` are absent. Unset does not read as "unknown" — the MCP spec defaults both to `true`, so the tool advertises itself as **destructive and open-world**. It is neither: its handler returns a fixed string and never reaches the API.

Two consequences. A client that honours annotations may prompt the user before every call. And OpenAI's MCP review flags the tool during submission scanning, which is the remaining warning on our submission after #196 lands.

Their own comment above that line already argues for the fix — it just stops one field short:

> Spec defaults assume the worst; declare the honest hint so annotation-aware clients skip the confirmation prompt.

## Why this shape

The tool is registered by the SDK, so it cannot be annotated where it is defined. There is no `_tool_manager` to reach into, and `get_tool` is async while `agentcat.track()` runs in synchronous startup code, so patching right after `track()` is not clean either.

`on_list_tools` returns `Sequence[Tool]`, so completing the annotations as the listing goes out is the supported path. Mutating `tool.annotations` is already the pattern used in `code_mode.py:225`.

Tools this server registers are untouched — the middleware only acts on names in `_INJECTED_TOOL_ANNOTATIONS`.

## Verification

End to end against a real server:

```
middleware registered : [..., ArgumentNormalizationMiddleware,
                         InjectedToolAnnotationMiddleware, ToolUsageLoggingMiddleware]
get_more_tools        -> readOnly=True destructive=False openWorld=False
list_incidents        -> readOnly=True openWorld=True        (unchanged)
```

```
pytest -q --no-cov           877 passed, 13 skipped   (main is 873; +4 here)
ruff check .                 All checks passed
ruff format --check .        61 files already formatted
pyright                      0 errors, 0 warnings
mypy src/rootly_mcp_server   Success: no issues found in 26 source files
bandit -r src/               0 issues
```

Confirmed the tests fail without the fix: neutralising the assignment line fails `test_completes_the_injected_tools_annotations`.

## Temporary

This has been reported upstream and should come out once the SDK sets the fields itself — a one-line change in three adapters. A test pins the tool name, so if the SDK renames `get_more_tools` the patch failing to apply shows up as a failure rather than silently doing nothing.

Stacks cleanly with #196, which fixes the annotations on tools we do register. This one covers only the tool we don't.