### PR TITLE
Finish the tool annotations, and fix the search result cap

### DIFF
--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -729,8 +729,13 @@ def register_incident_tools(
         """
         Search incidents with flexible pagination control.
 
-        Use page_number=0 to fetch all matching results across multiple pages up to max_results.
+        Use page_number=0 to fetch all matching results across multiple pages.
         Use page_number>0 to fetch a specific page.
+
+        max_results (also accepted as `limit`) caps how many incidents come back
+        in either mode: across pages when page_number=0, and within the page
+        otherwise. Left unset, a single page returns page_size incidents and
+        page_number=0 stops at 5.
 
         Argument caps: page_size <= 20, max_results <= 10. Values outside those
         bounds are clamped and reported, not rejected.

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -713,18 +713,18 @@ def register_incident_tools(
             int, Field(description="Page number to retrieve (use 0 for all pages)")
         ] = 1,
         max_results: Annotated[
-            int,
+            int | None,
             Field(
                 description=(
-                    "Maximum total results when fetching all pages "
-                    "(ignored if page_number > 0). Max: 10. For larger result sets, use "
-                    "page_number > 0 and paginate explicitly, or use collect_incidents."
+                    "Maximum incidents to return. Max: 10; defaults to 5 when fetching "
+                    "all pages, and to page_size when fetching a single page. For larger "
+                    "result sets, paginate with page_number > 0 or use collect_incidents."
                 ),
                 # `limit` is the name callers reach for, and it was the single
                 # most common rejected argument on this tool.
                 validation_alias=AliasChoices("max_results", "limit"),
             ),
-        ] = 5,
+        ] = None,
     ) -> JsonDict:
         """
         Search incidents with flexible pagination control.
@@ -738,12 +738,28 @@ def register_incident_tools(
         clamp = _ArgumentClamp()
         page_size = clamp("page_size", page_size, minimum=1, maximum=20)
         page_number = clamp("page_number", page_number, minimum=0)
-        max_results = clamp("max_results", max_results, minimum=1, maximum=10)
+        # Distinguish a caller-supplied cap from the default: it governs the page
+        # size on a single page, and only there when it was actually asked for.
+        requested_max_results = (
+            None
+            if max_results is None
+            else clamp("max_results", max_results, minimum=1, maximum=10)
+        )
+        max_results = 5 if requested_max_results is None else requested_max_results
 
         # Single page mode
         if page_number > 0:
+            # A caller asking for at most N results should not be handed a full
+            # page of page_size. This cap previously applied only when fetching
+            # all pages, so `limit=5` on the default page returned page_size rows
+            # and silently ignored the limit.
+            effective_page_size = (
+                page_size
+                if requested_max_results is None
+                else min(page_size, requested_max_results)
+            )
             params = {
-                "page[size]": page_size,  # Use requested page size (already limited to max 20)
+                "page[size]": effective_page_size,
                 "page[number]": page_number,
                 "include": "",
                 "fields[incidents]": INCIDENT_SEARCH_FIELDS,

--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -1895,7 +1895,11 @@ def register_oncall_tools(
             )
 
     @mcp.tool(
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            openWorldHint=True,
+        ),
     )
     async def list_shifts(
         from_date: Annotated[

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1788,3 +1788,49 @@ class TestInjectedToolAnnotations:
         from rootly_mcp_server.server import _INJECTED_TOOL_ANNOTATIONS
 
         assert constants.GET_MORE_TOOLS_NAME in _INJECTED_TOOL_ANNOTATIONS
+
+
+@pytest.mark.unit
+class TestEveryToolDeclaresItsSafety:
+    """No tool may leave a safety hint unset.
+
+    Unset is not "unknown": the MCP spec defaults destructiveHint and
+    openWorldHint to true, so an omission advertises the tool as destructive and
+    open-world. Annotation scanners flag it, and clients that honour annotations
+    may prompt before every call.
+
+    Annotating tools one at a time missed `list_shifts`, which is why this
+    asserts over the whole surface rather than a list someone has to maintain.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_tool_omits_destructive_hint(self, mock_environment_token):
+        server = create_rootly_mcp_server(hosted=False)
+
+        missing = [
+            tool.name
+            for tool in await server.list_tools()
+            if tool.annotations is not None and tool.annotations.destructiveHint is None
+        ]
+
+        assert missing == [], f"tools missing destructiveHint: {sorted(missing)}"
+
+    @pytest.mark.asyncio
+    async def test_no_tool_omits_open_world_hint(self, mock_environment_token):
+        server = create_rootly_mcp_server(hosted=False)
+
+        missing = [
+            tool.name
+            for tool in await server.list_tools()
+            if tool.annotations is not None and tool.annotations.openWorldHint is None
+        ]
+
+        assert missing == [], f"tools missing openWorldHint: {sorted(missing)}"
+
+    @pytest.mark.asyncio
+    async def test_every_tool_is_annotated_at_all(self, mock_environment_token):
+        server = create_rootly_mcp_server(hosted=False)
+
+        unannotated = [tool.name for tool in await server.list_tools() if tool.annotations is None]
+
+        assert unannotated == [], f"tools with no annotations: {sorted(unannotated)}"

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1775,10 +1775,16 @@ class TestInjectedToolAnnotations:
 
         assert result[0].annotations is None
 
-    @pytest.mark.asyncio
-    async def test_the_injected_tool_is_still_named_get_more_tools(self):
-        # Keyed by name: if the SDK renames the tool this patch silently stops
-        # applying, so pin the name we are compensating for.
+    def test_the_key_matches_the_name_the_sdk_registers(self):
+        """The patch is keyed by name, so an upstream rename disables it silently.
+
+        Compared against the SDK's own constant rather than a literal, so an
+        upgrade that renames the tool fails here. `agentcat` is installed only in
+        the container image, not by `uv sync --dev`, so this skips in the unit
+        test jobs and runs wherever the SDK is actually present.
+        """
+        constants = pytest.importorskip("agentcat.modules.constants")
+
         from rootly_mcp_server.server import _INJECTED_TOOL_ANNOTATIONS
 
-        assert "get_more_tools" in _INJECTED_TOOL_ANNOTATIONS
+        assert constants.GET_MORE_TOOLS_NAME in _INJECTED_TOOL_ANNOTATIONS

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1728,3 +1728,111 @@ class TestResultCountArgumentAliases:
 
         with pytest.raises(Exception, match="not_a_real_argument"):
             await mcp.call_tool("list_incidents", {"not_a_real_argument": 1})
+
+
+@pytest.mark.unit
+class TestSearchIncidentsResultCap:
+    """`limit` must limit on the default page, not only when fetching all pages.
+
+    `max_results` applied only in multi-page mode, and `limit` aliases it, so
+    `search_incidents(query=..., limit=5)` on the default page silently returned
+    a full page_size of rows. `limit` was the most frequently rejected argument
+    on this tool, so it was accepted and then ignored.
+
+    These run through a real FastMCP server: `limit` is a validation alias, and
+    calling the Python function directly bypasses it entirely.
+    """
+
+    @staticmethod
+    def _params(request):
+        """The params of the most recent call, asserted to exist."""
+        call_args = request.await_args
+        assert call_args is not None, "expected a request to have been made"
+        return call_args.kwargs["params"]
+
+    @staticmethod
+    def _server():
+        from fastmcp import FastMCP
+
+        async def responder(method, url, params=None, **_kwargs):
+            # The API returns at most page[size] rows; mirror that or the cap
+            # under test cannot be observed.
+            size = min(int((params or {}).get("page[size]", 10)), 10)
+            response = Mock()
+            response.raise_for_status.return_value = None
+            response.json.return_value = {
+                "data": [
+                    {"id": f"i{i}", "type": "incidents", "attributes": {"title": f"t{i}"}}
+                    for i in range(size)
+                ],
+                "meta": {"current_page": 1, "next_page": None, "total_pages": 1},
+            }
+            return response
+
+        request = AsyncMock(side_effect=responder)
+        mcp = FastMCP("search-cap-probe")
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=False,
+        )
+        return mcp, request
+
+    @staticmethod
+    async def _search(mcp, **arguments):
+        result = await mcp.call_tool("search_incidents", {"query": "db", **arguments})
+        payload = result.structured_content
+        assert payload is not None
+        return payload
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("name", ["limit", "max_results"])
+    async def test_the_cap_applies_on_the_default_page(self, name):
+        mcp, request = self._server()
+
+        payload = await self._search(mcp, **{name: 5})
+
+        assert self._params(request)["page[size]"] == 5
+        assert len(payload["data"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_the_smaller_of_the_two_wins(self):
+        mcp, request = self._server()
+
+        await self._search(mcp, limit=5, page_size=3)
+
+        assert self._params(request)["page[size]"] == 3
+
+    @pytest.mark.asyncio
+    async def test_no_cap_leaves_the_page_size_alone(self):
+        # The regression guard: an existing caller that never passed a cap must
+        # keep receiving a full page.
+        mcp, request = self._server()
+
+        payload = await self._search(mcp)
+
+        assert self._params(request)["page[size]"] == 10
+        assert len(payload["data"]) == 10
+
+    @pytest.mark.asyncio
+    async def test_multi_page_mode_is_unchanged(self):
+        mcp, _ = self._server()
+
+        capped = await self._search(mcp, limit=5, page_number=0)
+        defaulted = await self._search(mcp, page_number=0)
+
+        assert len(capped["data"]) == 5
+        # Still defaults to 5 across pages when no cap is given.
+        assert len(defaulted["data"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_an_over_large_cap_is_still_clamped_and_reported(self):
+        mcp, request = self._server()
+
+        payload = await self._search(mcp, limit=20)
+
+        assert self._params(request)["page[size]"] == 10
+        assert "max_results=20" in payload["argument_adjustments"][0]


### PR DESCRIPTION
Three follow-ups to the OpenAI submission work, consolidated. Two came from Greptile findings on #196 and #197; one is the last annotation the scan flagged.

---

## 1. `list_shifts` was missing `destructiveHint`

The one read-only tool #196 missed. On `main` it declared only `readOnlyHint`, and unset is not "unknown" — the MCP spec defaults `destructiveHint` to `true`, so the tool advertised itself as destructive and the submission scan flagged it.

I scanned every `ToolAnnotations` across `oncall.py`, `incidents.py`, `alerts.py` and `server.py`. This was the only one.

**A guard so it cannot recur.** Annotating tools one at a time is what missed it, so this asserts over every tool the server lists rather than a roster someone maintains: no tool omits `destructiveHint`, none omits `openWorldHint`, none is unannotated. Reverting the one-line fix fails with:

```
AssertionError: tools missing destructiveHint: ['list_shifts']
```

It covers curated and autogenerated tools alike. It deliberately cannot see `get_more_tools` — AgentCat injects that one and it is not in the local listing, which is why #197 handles it at the middleware layer.

## 2. The `get_more_tools` name is now pinned to the SDK's constant

The test guarding #197's patch asserted that our own dictionary contained the key we had just written into it — true by construction, and unable to fail. The regression it claimed to cover, the SDK renaming the tool and silently disabling the patch, would have gone undetected. Greptile called this out on #197.

It now compares against `agentcat.modules.constants.GET_MORE_TOOLS_NAME`.

Narrower than it looks, and the docstring says so: `agentcat` is installed only in the container image, not by `uv sync --dev`, so this **skips in the unit test jobs** and runs wherever the SDK is present. Still strictly better than an assertion that cannot fail.

## 3. The search result cap did not apply on the default page

`search_incidents` takes `max_results`, aliased as `limit`, but honoured it only when fetching all pages. `page_number` defaults to 1, so the ordinary call set the cap and ignored it:

```
call                          page[size] sent   returned
──────────────────────────────────────────────────────────
limit=5,       default page        10             10   ← ignored
limit=5,       page_number=0       10              5   ← worked
```

A caller asking for 5 got 10. `limit` was the single most rejected argument on this tool — 87 Sentry events in 14 days — and #188 accepted it into a no-op, trading a clear rejection for a silently larger result set.

The cap now bounds the page size on a single page too, using the smaller of `page_size` and the requested cap. `max_results` defaults to `None` so a caller-supplied cap is distinguishable from the default; when absent nothing changes.

```
call                          page[size] sent   returned
──────────────────────────────────────────────────────────
no cap,        default page        10             10    unchanged
limit=5,       default page         5              5    fixed
limit=5,       page_size=3           3              3    smaller wins
limit=5,       page_number=0        10              5    unchanged
no cap,        page_number=0        10              5    unchanged
```

Two alternatives rejected. Pointing `limit` at `page_size` would change its meaning between modes — in all-pages mode `page_size` is per-page, so `limit=20` would return 5. Making `max_results` always cap would drop every no-argument call from 10 rows to 5, a silent change for callers who never asked for one.

---

## Tests

The `search_incidents` tests run through a **real FastMCP server**. `limit` is a validation alias, so calling the function directly bypasses it — against the test double they pass whether or not the alias exists, which is how the original gap survived review.

Verified both fixes fail without their change: neutralising the page-size calculation gives `assert 10 == 5`, the exact production symptom; reverting the annotation names `list_shifts`.

```
pytest -q --no-cov           900 passed, 14 skipped
ruff check .                 All checks passed
ruff format --check .        61 files already formatted
pyright                      0 errors, 0 warnings
mypy src/rootly_mcp_server   Success: no issues found in 26 source files
bandit -r src/               0 issues
```

Supersedes #199 and #200, both closed in favour of this.