### PR TITLE
Make the search result cap apply on the default page

### DIFF
--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -713,18 +713,18 @@ def register_incident_tools(
             int, Field(description="Page number to retrieve (use 0 for all pages)")
         ] = 1,
         max_results: Annotated[
-            int,
+            int | None,
             Field(
                 description=(
-                    "Maximum total results when fetching all pages "
-                    "(ignored if page_number > 0). Max: 10. For larger result sets, use "
-                    "page_number > 0 and paginate explicitly, or use collect_incidents."
+                    "Maximum incidents to return. Max: 10; defaults to 5 when fetching "
+                    "all pages, and to page_size when fetching a single page. For larger "
+                    "result sets, paginate with page_number > 0 or use collect_incidents."
                 ),
                 # `limit` is the name callers reach for, and it was the single
                 # most common rejected argument on this tool.
                 validation_alias=AliasChoices("max_results", "limit"),
             ),
-        ] = 5,
+        ] = None,
     ) -> JsonDict:
         """
         Search incidents with flexible pagination control.
@@ -738,12 +738,28 @@ def register_incident_tools(
         clamp = _ArgumentClamp()
         page_size = clamp("page_size", page_size, minimum=1, maximum=20)
         page_number = clamp("page_number", page_number, minimum=0)
-        max_results = clamp("max_results", max_results, minimum=1, maximum=10)
+        # Distinguish a caller-supplied cap from the default: it governs the page
+        # size on a single page, and only there when it was actually asked for.
+        requested_max_results = (
+            None
+            if max_results is None
+            else clamp("max_results", max_results, minimum=1, maximum=10)
+        )
+        max_results = 5 if requested_max_results is None else requested_max_results
 
         # Single page mode
         if page_number > 0:
+            # A caller asking for at most N results should not be handed a full
+            # page of page_size. This cap previously applied only when fetching
+            # all pages, so `limit=5` on the default page returned page_size rows
+            # and silently ignored the limit.
+            effective_page_size = (
+                page_size
+                if requested_max_results is None
+                else min(page_size, requested_max_results)
+            )
             params = {
-                "page[size]": page_size,  # Use requested page size (already limited to max 20)
+                "page[size]": effective_page_size,
                 "page[number]": page_number,
                 "include": "",
                 "fields[incidents]": INCIDENT_SEARCH_FIELDS,

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -1728,3 +1728,111 @@ class TestResultCountArgumentAliases:
 
         with pytest.raises(Exception, match="not_a_real_argument"):
             await mcp.call_tool("list_incidents", {"not_a_real_argument": 1})
+
+
+@pytest.mark.unit
+class TestSearchIncidentsResultCap:
+    """`limit` must limit on the default page, not only when fetching all pages.
+
+    `max_results` applied only in multi-page mode, and `limit` aliases it, so
+    `search_incidents(query=..., limit=5)` on the default page silently returned
+    a full page_size of rows. `limit` was the most frequently rejected argument
+    on this tool, so it was accepted and then ignored.
+
+    These run through a real FastMCP server: `limit` is a validation alias, and
+    calling the Python function directly bypasses it entirely.
+    """
+
+    @staticmethod
+    def _params(request):
+        """The params of the most recent call, asserted to exist."""
+        call_args = request.await_args
+        assert call_args is not None, "expected a request to have been made"
+        return call_args.kwargs["params"]
+
+    @staticmethod
+    def _server():
+        from fastmcp import FastMCP
+
+        async def responder(method, url, params=None, **_kwargs):
+            # The API returns at most page[size] rows; mirror that or the cap
+            # under test cannot be observed.
+            size = min(int((params or {}).get("page[size]", 10)), 10)
+            response = Mock()
+            response.raise_for_status.return_value = None
+            response.json.return_value = {
+                "data": [
+                    {"id": f"i{i}", "type": "incidents", "attributes": {"title": f"t{i}"}}
+                    for i in range(size)
+                ],
+                "meta": {"current_page": 1, "next_page": None, "total_pages": 1},
+            }
+            return response
+
+        request = AsyncMock(side_effect=responder)
+        mcp = FastMCP("search-cap-probe")
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=False,
+        )
+        return mcp, request
+
+    @staticmethod
+    async def _search(mcp, **arguments):
+        result = await mcp.call_tool("search_incidents", {"query": "db", **arguments})
+        payload = result.structured_content
+        assert payload is not None
+        return payload
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("name", ["limit", "max_results"])
+    async def test_the_cap_applies_on_the_default_page(self, name):
+        mcp, request = self._server()
+
+        payload = await self._search(mcp, **{name: 5})
+
+        assert self._params(request)["page[size]"] == 5
+        assert len(payload["data"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_the_smaller_of_the_two_wins(self):
+        mcp, request = self._server()
+
+        await self._search(mcp, limit=5, page_size=3)
+
+        assert self._params(request)["page[size]"] == 3
+
+    @pytest.mark.asyncio
+    async def test_no_cap_leaves_the_page_size_alone(self):
+        # The regression guard: an existing caller that never passed a cap must
+        # keep receiving a full page.
+        mcp, request = self._server()
+
+        payload = await self._search(mcp)
+
+        assert self._params(request)["page[size]"] == 10
+        assert len(payload["data"]) == 10
+
+    @pytest.mark.asyncio
+    async def test_multi_page_mode_is_unchanged(self):
+        mcp, _ = self._server()
+
+        capped = await self._search(mcp, limit=5, page_number=0)
+        defaulted = await self._search(mcp, page_number=0)
+
+        assert len(capped["data"]) == 5
+        # Still defaults to 5 across pages when no cap is given.
+        assert len(defaulted["data"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_an_over_large_cap_is_still_clamped_and_reported(self):
+        mcp, request = self._server()
+
+        payload = await self._search(mcp, limit=20)
+
+        assert self._params(request)["page[size]"] == 10
+        assert "max_results=20" in payload["argument_adjustments"][0]


### PR DESCRIPTION
Raised by Greptile on #196. The finding is correct, but it predates that PR — the alias landed in #188 and is live in production, so #196 inherited it rather than causing it. Fixing it here on its own.

## Problem

`search_incidents` takes `max_results`, aliased as `limit`, but honoured it **only when fetching all pages**. `page_number` defaults to 1, so the ordinary call set the cap and then ignored it:

```
call                          page[size] sent   returned
──────────────────────────────────────────────────────────
limit=5,       default page        10             10   ← ignored
max_results=5, default page        10             10   ← ignored
limit=5,       page_number=0       10              5   ← worked
```

A caller asking for 5 got 10.

This is the failure the alias existed to remove. `limit` was the single most frequently rejected argument on this tool — 87 events in Sentry over 14 days — and #188 accepted it into a no-op, trading a clear rejection for a silently larger result set. That is the same shape as the `service_name → query` mapping rejected during #196's review.

## Change

The cap now bounds the page size on a single page too, using the smaller of `page_size` and the requested cap.

To distinguish a caller-supplied cap from the default, `max_results` now defaults to `None`. When it is absent nothing changes: a single page still returns `page_size` rows, and all-pages mode still stops at 5.

```
call                          page[size] sent   returned
──────────────────────────────────────────────────────────
no cap,        default page        10             10    unchanged
limit=5,       default page         5              5    fixed
max_results=5, default page         5              5    fixed
limit=5,       page_size=3           3              3    smaller wins
limit=5,       page_number=0        10              5    unchanged
no cap,        page_number=0        10              5    unchanged
```

## Why not the alternatives

**Point `limit` at `page_size` instead.** Works on a single page, but in all-pages mode `page_size` is per-page rather than a total, so `limit=20` would return 5 — the `max_results` default. The meaning would change with the mode.

**Make `max_results` always cap.** Its default is 5 while `page_size` defaults to 10, so every existing no-argument call would drop from 10 rows to 5. A silent behaviour change for callers who never asked for one.

## Tests

Six new, running through a **real FastMCP server**. `limit` is a validation alias, so calling the function directly bypasses it — against the test double these pass whether or not the alias exists, which is how the original gap survived review.

Verified they fail without the fix: neutralising the page-size calculation fails both cap tests with `assert 10 == 5`, the exact production symptom.

```
pytest -q --no-cov           898 passed, 13 skipped
ruff check .                 All checks passed
ruff format --check .        61 files already formatted
pyright                      0 errors, 0 warnings
mypy src/rootly_mcp_server   Success: no issues found in 26 source files
bandit -r src/               0 issues
```