### PR TITLE
Annotate list_shifts, and assert over the whole tool surface

### DIFF
--- a/src/rootly_mcp_server/tools/oncall.py
+++ b/src/rootly_mcp_server/tools/oncall.py
@@ -1895,7 +1895,11 @@ def register_oncall_tools(
             )
 
     @mcp.tool(
-        annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            openWorldHint=True,
+        ),
     )
     async def list_shifts(
         from_date: Annotated[

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -1782,3 +1782,49 @@ class TestInjectedToolAnnotations:
         from rootly_mcp_server.server import _INJECTED_TOOL_ANNOTATIONS
 
         assert "get_more_tools" in _INJECTED_TOOL_ANNOTATIONS
+
+
+@pytest.mark.unit
+class TestEveryToolDeclaresItsSafety:
+    """No tool may leave a safety hint unset.
+
+    Unset is not "unknown": the MCP spec defaults destructiveHint and
+    openWorldHint to true, so an omission advertises the tool as destructive and
+    open-world. Annotation scanners flag it, and clients that honour annotations
+    may prompt before every call.
+
+    Annotating tools one at a time missed `list_shifts`, which is why this
+    asserts over the whole surface rather than a list someone has to maintain.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_tool_omits_destructive_hint(self, mock_environment_token):
+        server = create_rootly_mcp_server(hosted=False)
+
+        missing = [
+            tool.name
+            for tool in await server.list_tools()
+            if tool.annotations is not None and tool.annotations.destructiveHint is None
+        ]
+
+        assert missing == [], f"tools missing destructiveHint: {sorted(missing)}"
+
+    @pytest.mark.asyncio
+    async def test_no_tool_omits_open_world_hint(self, mock_environment_token):
+        server = create_rootly_mcp_server(hosted=False)
+
+        missing = [
+            tool.name
+            for tool in await server.list_tools()
+            if tool.annotations is not None and tool.annotations.openWorldHint is None
+        ]
+
+        assert missing == [], f"tools missing openWorldHint: {sorted(missing)}"
+
+    @pytest.mark.asyncio
+    async def test_every_tool_is_annotated_at_all(self, mock_environment_token):
+        server = create_rootly_mcp_server(hosted=False)
+
+        unannotated = [tool.name for tool in await server.list_tools() if tool.annotations is None]
+
+        assert unannotated == [], f"tools with no annotations: {sorted(unannotated)}"


### PR DESCRIPTION
## Problem

`list_shifts` was the one read-only tool #196 missed. On `main` it still declares only `readOnlyHint`:

```python
# src/rootly_mcp_server/tools/oncall.py:1898
annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),
```

Unset is not "unknown" — the MCP spec defaults `destructiveHint` to `true`, so the tool advertises itself as destructive and the OpenAI submission scan flags it.

I scanned every `ToolAnnotations` across `oncall.py`, `incidents.py`, `alerts.py` and `server.py` for read-only tools without `destructiveHint`. This was the only one.

## Change

Two things. The one-line annotation fix, and a guard so the class of bug cannot recur.

Annotating tools one at a time is exactly what missed this, so the guard asserts over **every tool the server lists** rather than a roster someone has to keep in step:

- no tool omits `destructiveHint`
- no tool omits `openWorldHint`
- no tool is unannotated

It covers curated and autogenerated tools alike, and it names the offender on failure. Reverting the one-line fix produces:

```
AssertionError: tools missing destructiveHint: ['list_shifts']
```

That is the check that would have caught this during #196.

## Scope

This does not cover `get_more_tools` — that tool is injected by AgentCat and is not in this server's listing locally, so the guard cannot see it. It is handled separately by the middleware in #197, which is merged.

Between the two, all three remaining submission warnings are addressed once both are deployed.

## Verification

```
pytest -q --no-cov           895 passed, 13 skipped
ruff check .                 All checks passed
ruff format --check .        61 files already formatted
pyright                      0 errors, 0 warnings
mypy src/rootly_mcp_server   Success: no issues found in 26 source files
bandit -r src/               0 issues
```