### PR TITLE
Read an incident's call transcripts in one call

### DIFF
--- a/src/rootly_mcp_server/server_defaults.py
+++ b/src/rootly_mcp_server/server_defaults.py
@@ -68,6 +68,7 @@ DEFAULT_HOSTED_ENABLED_TOOLS: frozenset[str] = frozenset(
         "get_escalation_policy",
         "get_functionality",
         "get_incident",
+        "get_incident_meeting_transcripts",
         "get_meeting_recording",
         "get_oncall_handoff_summary",
         "get_oncall_schedule_summary",

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -130,6 +130,85 @@ def _summarize_incident_record(incident: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# One line per speaker turn instead of one object per word. The API passes
+# through raw speech-to-text output, where every word carries its own
+# confidence and start/end timestamps -- 125 bytes of JSON per spoken word,
+# measured. That shape exists to drive a UI with timestamps synced to video;
+# for a model reading a conversation it is 93% overhead. A 40-minute call is
+# ~731 KB word-level against ~47 KB collapsed.
+TRANSCRIPT_MAX_RECORDINGS_DEFAULT = 3
+TRANSCRIPT_MAX_RECORDINGS = 10
+TRANSCRIPT_MAX_CHARS = 40_000
+
+
+def _collapse_transcript_segments(transcript: Any) -> list[dict[str, str]]:
+    """Turn the API's per-word arrays into one text block per speaker turn."""
+    if not isinstance(transcript, list):
+        return []
+    segments: list[dict[str, str]] = []
+    for segment in transcript:
+        if not isinstance(segment, dict):
+            continue
+        words = segment.get("words")
+        if isinstance(words, list):
+            text = " ".join(
+                str(word.get("text", "")) for word in words if isinstance(word, dict)
+            ).strip()
+        else:
+            # Tolerate a future shape that already returns text.
+            text = str(segment.get("text") or "").strip()
+        if not text:
+            continue
+        collapsed = {"text": text}
+        speaker = segment.get("speaker")
+        if speaker:
+            collapsed["speaker"] = str(speaker)
+        language = segment.get("language")
+        if language:
+            collapsed["language"] = str(language)
+        segments.append(collapsed)
+    return segments
+
+
+def _truncate_transcript_segments(
+    segments: list[dict[str, str]], *, budget: int
+) -> tuple[list[dict[str, str]], bool]:
+    """Keep whole speaker turns until the character budget is spent."""
+    kept: list[dict[str, str]] = []
+    spent = 0
+    for segment in segments:
+        length = len(segment["text"])
+        if kept and spent + length > budget:
+            return kept, True
+        kept.append(segment)
+        spent += length
+        if spent > budget:
+            # The first turn alone can exceed the budget; keep it but stop.
+            return kept, len(kept) < len(segments)
+    return kept, False
+
+
+def _summarize_recording(recording: dict[str, Any]) -> dict[str, Any]:
+    """Recording metadata worth returning, without the signed video URL.
+
+    `video_url` is a presigned S3 link of roughly two kilobytes, mostly AWS
+    credential query string, and it expires in an hour. It is dead weight in a
+    transcript response.
+    """
+    attrs = recording.get("attributes") or {}
+    return {
+        "recording_id": recording.get("id"),
+        "platform": attrs.get("platform"),
+        "status": attrs.get("status"),
+        "started_at": attrs.get("started_at"),
+        "ended_at": attrs.get("ended_at"),
+        "duration_minutes": attrs.get("duration_minutes"),
+        "speaker_count": attrs.get("speaker_count"),
+        "word_count": attrs.get("word_count"),
+        "summary": attrs.get("transcript_summary"),
+    }
+
+
 def _extract_sequential_id(incident: dict[str, Any]) -> int | None:
     """Extract a numeric sequential incident ID from a Rootly incident record."""
     attrs = incident.get("attributes") or {}
@@ -1012,6 +1091,165 @@ def register_incident_tools(
             )
         except Exception as e:
             return _reference_tool_error("Failed to list incident roles", e)
+
+    @mcp.tool(
+        name="get_incident_meeting_transcripts",
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            openWorldHint=True,
+        ),
+    )
+    async def get_incident_meeting_transcripts(
+        incident_id: Annotated[
+            str,
+            Field(
+                description=("Incident UUID or number (e.g. '5185', '#5185', 'INC-5185')."),
+                validation_alias=AliasChoices("incident_id", "id"),
+            ),
+        ],
+        max_recordings: Annotated[
+            int | None,
+            Field(
+                description=(
+                    f"How many recordings to read transcripts for, newest first. "
+                    f"Max: {TRANSCRIPT_MAX_RECORDINGS}; defaults to "
+                    f"{TRANSCRIPT_MAX_RECORDINGS_DEFAULT}."
+                ),
+                validation_alias=AliasChoices("max_recordings", "limit", "max_results"),
+            ),
+        ] = None,
+    ) -> JsonDict:
+        """
+        Read what was said on an incident's calls (Rootly Meeting Scribe).
+
+        Returns the spoken transcript of each recorded call for the incident, as
+        text per speaker turn, alongside Scribe's own summary. Covers Google Meet,
+        Zoom and Microsoft Teams calls that Scribe recorded.
+
+        Use this to catch up on a call you missed, or to pull decisions and
+        actions out of an incident bridge. Recordings where nobody spoke are
+        skipped rather than returned empty.
+        """
+        clamp = _ArgumentClamp()
+        requested = (
+            None
+            if max_recordings is None
+            else clamp(
+                "max_recordings",
+                max_recordings,
+                minimum=1,
+                maximum=TRANSCRIPT_MAX_RECORDINGS,
+            )
+        )
+        limit = TRANSCRIPT_MAX_RECORDINGS_DEFAULT if requested is None else requested
+
+        try:
+            resolved_incident_id = await _resolve_incident_reference_to_uuid(
+                incident_id, make_authenticated_request
+            )
+        except ValueError as e:
+            return cast(JsonDict, mcp_error.tool_error(str(e), "validation_error"))
+        except LookupError as e:
+            return cast(JsonDict, mcp_error.tool_error(str(e), "not_found"))
+        except Exception as e:
+            return _reference_tool_error("Failed to resolve incident", e)
+
+        notes: list[str] = []
+        try:
+            listing = await make_authenticated_request(
+                "GET",
+                f"/v1/incidents/{resolved_incident_id}/meeting_recordings",
+                params={"page[size]": limit, "page[number]": 1},
+            )
+            listing.raise_for_status()
+            records = listing.json().get("data") or []
+        except Exception as e:
+            error_type, error_message = mcp_error.categorize_error(e)
+            return cast(
+                JsonDict,
+                mcp_error.tool_error(
+                    f"Failed to list meeting recordings: {error_message}", error_type
+                ),
+            )
+
+        if not records:
+            return clamp.apply(
+                {
+                    "incident_id": resolved_incident_id,
+                    "recordings": [],
+                    "returned_recordings": 0,
+                    "notes": ["No Meeting Scribe recordings exist for this incident."],
+                }
+            )
+
+        # Decide what to read before dividing the budget, so silent recordings
+        # do not take a share of it. Nine silent recordings alongside one real
+        # call should not leave that call with a tenth of the allowance.
+        readable: list[JsonDict] = []
+        skipped_silent = 0
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            summary = _summarize_recording(record)
+            word_count = summary.get("word_count")
+            # A recording where nobody spoke has no transcript to fetch; asking
+            # for one costs a request and returns an empty array.
+            if isinstance(word_count, int) and word_count == 0:
+                skipped_silent += 1
+                continue
+            if not summary.get("recording_id"):
+                continue
+            readable.append(summary)
+
+        # Spend the budget across the calls actually being read, so one long
+        # call cannot crowd out the rest.
+        per_recording_budget = max(TRANSCRIPT_MAX_CHARS // max(len(readable), 1), 1_000)
+        recordings: list[JsonDict] = []
+
+        for summary in readable:
+            recording_id = summary["recording_id"]
+            try:
+                detail = await make_authenticated_request(
+                    "GET",
+                    f"/v1/meeting_recordings/{recording_id}",
+                    params={"include": "transcript"},
+                )
+                detail.raise_for_status()
+                attributes = (detail.json().get("data") or {}).get("attributes") or {}
+            except Exception as e:
+                _, error_message = mcp_error.categorize_error(e)
+                summary["transcript"] = []
+                summary["error"] = f"Failed to read transcript: {error_message}"
+                recordings.append(summary)
+                continue
+
+            segments = _collapse_transcript_segments(attributes.get("transcript"))
+            kept, truncated = _truncate_transcript_segments(segments, budget=per_recording_budget)
+            summary["transcript"] = kept
+            if truncated:
+                summary["transcript_truncated"] = True
+                notes.append(
+                    f"Recording {recording_id} was truncated at "
+                    f"{per_recording_budget} characters; "
+                    f"{len(segments) - len(kept)} later speaker turn(s) omitted."
+                )
+            recordings.append(summary)
+
+        if skipped_silent:
+            notes.append(
+                f"Skipped {skipped_silent} recording(s) with no speech; "
+                "Scribe joined but nobody spoke."
+            )
+
+        result: JsonDict = {
+            "incident_id": resolved_incident_id,
+            "recordings": recordings,
+            "returned_recordings": len(recordings),
+        }
+        if notes:
+            result["notes"] = notes
+        return clamp.apply(result)
 
     if enable_write_tools:
 

--- a/src/rootly_mcp_server/tools/incidents.py
+++ b/src/rootly_mcp_server/tools/incidents.py
@@ -139,6 +139,14 @@ def _summarize_incident_record(incident: dict[str, Any]) -> dict[str, Any]:
 TRANSCRIPT_MAX_RECORDINGS_DEFAULT = 3
 TRANSCRIPT_MAX_RECORDINGS = 10
 TRANSCRIPT_MAX_CHARS = 40_000
+# Most recordings in production have no speech at all -- Scribe joined a call
+# that never happened. Asking the API for exactly as many recordings as the
+# caller wants transcripts for therefore returns nothing useful most of the
+# time, so read a full page and keep turning pages until enough recordings
+# with speech are found. The page cap bounds the work when an incident has a
+# long tail of silent recordings.
+TRANSCRIPT_LIST_PAGE_SIZE = 50
+TRANSCRIPT_MAX_LIST_PAGES = 5
 
 
 def _collapse_transcript_segments(transcript: Any) -> list[dict[str, str]]:
@@ -1156,24 +1164,66 @@ def register_incident_tools(
             return _reference_tool_error("Failed to resolve incident", e)
 
         notes: list[str] = []
-        try:
-            listing = await make_authenticated_request(
-                "GET",
-                f"/v1/incidents/{resolved_incident_id}/meeting_recordings",
-                params={"page[size]": limit, "page[number]": 1},
-            )
-            listing.raise_for_status()
-            records = listing.json().get("data") or []
-        except Exception as e:
-            error_type, error_message = mcp_error.categorize_error(e)
-            return cast(
-                JsonDict,
-                mcp_error.tool_error(
-                    f"Failed to list meeting recordings: {error_message}", error_type
-                ),
+        readable: list[JsonDict] = []
+        skipped_silent = 0
+        any_records = False
+        pages_read = 0
+        more_pages = True
+
+        while more_pages and len(readable) < limit and pages_read < TRANSCRIPT_MAX_LIST_PAGES:
+            pages_read += 1
+            try:
+                listing = await make_authenticated_request(
+                    "GET",
+                    f"/v1/incidents/{resolved_incident_id}/meeting_recordings",
+                    params={
+                        "page[size]": TRANSCRIPT_LIST_PAGE_SIZE,
+                        "page[number]": pages_read,
+                    },
+                )
+                listing.raise_for_status()
+                body = listing.json()
+            except Exception as e:
+                if readable:
+                    # Keep what was already found rather than losing it all.
+                    _, error_message = mcp_error.categorize_error(e)
+                    notes.append(f"Stopped listing recordings early: {error_message}")
+                    break
+                error_type, error_message = mcp_error.categorize_error(e)
+                return cast(
+                    JsonDict,
+                    mcp_error.tool_error(
+                        f"Failed to list meeting recordings: {error_message}", error_type
+                    ),
+                )
+
+            records = body.get("data") or []
+            any_records = any_records or bool(records)
+            for record in records:
+                if not isinstance(record, dict):
+                    continue
+                summary = _summarize_recording(record)
+                word_count = summary.get("word_count")
+                # A recording where nobody spoke has no transcript to fetch;
+                # asking for one costs a request and returns an empty array.
+                if isinstance(word_count, int) and word_count == 0:
+                    skipped_silent += 1
+                    continue
+                if not summary.get("recording_id"):
+                    continue
+                readable.append(summary)
+                if len(readable) >= limit:
+                    break
+
+            more_pages = bool((body.get("meta") or {}).get("next_page"))
+
+        if more_pages and len(readable) < limit:
+            notes.append(
+                f"Stopped after scanning {pages_read} page(s) of recordings; "
+                "more may exist. Raise max_recordings or query a narrower incident."
             )
 
-        if not records:
+        if not any_records:
             return clamp.apply(
                 {
                     "incident_id": resolved_incident_id,
@@ -1182,25 +1232,6 @@ def register_incident_tools(
                     "notes": ["No Meeting Scribe recordings exist for this incident."],
                 }
             )
-
-        # Decide what to read before dividing the budget, so silent recordings
-        # do not take a share of it. Nine silent recordings alongside one real
-        # call should not leave that call with a tenth of the allowance.
-        readable: list[JsonDict] = []
-        skipped_silent = 0
-        for record in records:
-            if not isinstance(record, dict):
-                continue
-            summary = _summarize_recording(record)
-            word_count = summary.get("word_count")
-            # A recording where nobody spoke has no transcript to fetch; asking
-            # for one costs a request and returns an empty array.
-            if isinstance(word_count, int) and word_count == 0:
-                skipped_silent += 1
-                continue
-            if not summary.get("recording_id"):
-                continue
-            readable.append(summary)
 
         # Spend the budget across the calls actually being read, so one long
         # call cannot crowd out the rest.

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -9,6 +9,7 @@ Tests cover:
 - Error handling and response formatting
 """
 
+import json
 from typing import Any
 from unittest.mock import AsyncMock, Mock, call, patch
 
@@ -1836,3 +1837,330 @@ class TestSearchIncidentsResultCap:
 
         assert self._params(request)["page[size]"] == 10
         assert "max_results=20" in payload["argument_adjustments"][0]
+
+
+def _recording_record(rec_id, *, word_count=41, platform="google_meet"):
+    return {
+        "id": rec_id,
+        "type": "meeting_recordings",
+        "attributes": {
+            "platform": platform,
+            "status": "completed",
+            "started_at": "2026-09-02T16:37:56-07:00",
+            "ended_at": "2026-09-02T16:38:17-07:00",
+            "duration_minutes": 0,
+            "speaker_count": 1,
+            "word_count": word_count,
+            "transcript_summary": "Ten customers reported search was slow.",
+            # ~2KB of presigned AWS query string in production.
+            "video_url": "https://rootly-storage.s3.amazonaws.com/x?X-Amz-Credential=" + "A" * 400,
+        },
+    }
+
+
+def _word_transcript(*turns):
+    """The API's shape: one object per word, with confidence and timings."""
+    return [
+        {
+            "speaker": speaker,
+            "language": "en_us",
+            "speaker_id": None,
+            "words": [
+                {
+                    "text": word,
+                    "language": None,
+                    "confidence": 0.97,
+                    "start_timestamp": i * 0.3,
+                    "end_timestamp": i * 0.3 + 0.2,
+                }
+                for i, word in enumerate(text.split())
+            ],
+        }
+        for speaker, text in turns
+    ]
+
+
+@pytest.mark.unit
+class TestIncidentMeetingTranscripts:
+    """Reading an incident's call transcripts used to take three calls.
+
+    Resolve the incident, list its recordings, then fetch each one with
+    `include=transcript` -- and the caller had to know that `include` value
+    exists, since it appears nowhere in the bundled spec. The API also returns
+    one object per spoken word, which is 125 bytes of JSON per word.
+    """
+
+    @staticmethod
+    def _register(*, recordings=None, transcript=None, detail_error=False):
+        mcp = FakeMCP()
+        recordings = [] if recordings is None else recordings
+
+        async def responder(method, url, params=None, **_kwargs):
+            response = Mock()
+            response.raise_for_status.return_value = None
+            if url == "/v1/incidents":  # sequential-id resolution
+                response.json.return_value = {
+                    "data": [{"id": "inc-uuid", "attributes": {"sequential_id": 5185}}]
+                }
+            elif url.endswith("/meeting_recordings"):
+                response.json.return_value = {"data": recordings}
+            elif "/v1/meeting_recordings/" in url:
+                if detail_error:
+                    raise RuntimeError("upstream exploded")
+                response.json.return_value = {
+                    "data": {"attributes": {"transcript": transcript or []}}
+                }
+            else:
+                response.json.return_value = {"data": {}}
+            return response
+
+        request = AsyncMock(side_effect=responder)
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=False,
+        )
+        return mcp.tools, request
+
+    @pytest.mark.asyncio
+    async def test_word_level_output_becomes_text_per_speaker_turn(self):
+        tools, _ = self._register(
+            recordings=[_recording_record("rec-1")],
+            transcript=_word_transcript(
+                ("Luca Tirelli", "we have about 10 customers reporting slow search"),
+                ("Ada Lovelace", "starting the investigation now"),
+            ),
+        )
+
+        result = await tools["get_incident_meeting_transcripts"](incident_id="INC-5185")
+
+        assert result["returned_recordings"] == 1
+        assert result["recordings"][0]["transcript"] == [
+            {
+                "text": "we have about 10 customers reporting slow search",
+                "speaker": "Luca Tirelli",
+                "language": "en_us",
+            },
+            {
+                "text": "starting the investigation now",
+                "speaker": "Ada Lovelace",
+                "language": "en_us",
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_the_signed_video_url_is_not_returned(self):
+        # ~2KB of AWS credential query string per record, expiring in an hour.
+        tools, _ = self._register(
+            recordings=[_recording_record("rec-1")],
+            transcript=_word_transcript(("Luca", "hello")),
+        )
+
+        result = await tools["get_incident_meeting_transcripts"](incident_id="5185")
+
+        assert "video_url" not in result["recordings"][0]
+        assert "X-Amz-Credential" not in json.dumps(result)
+
+    @pytest.mark.asyncio
+    async def test_recordings_where_nobody_spoke_are_skipped(self):
+        tools, request = self._register(
+            recordings=[
+                _recording_record("silent", word_count=0),
+                _recording_record("spoken", word_count=12),
+            ],
+            transcript=_word_transcript(("Luca", "we are live")),
+        )
+
+        result = await tools["get_incident_meeting_transcripts"](incident_id="5185")
+
+        assert result["returned_recordings"] == 1
+        assert result["recordings"][0]["recording_id"] == "spoken"
+        assert any("nobody spoke" in note for note in result["notes"])
+        # And no request was wasted fetching the empty one.
+        fetched = [
+            c.args[1] for c in request.await_args_list if "/v1/meeting_recordings/" in c.args[1]
+        ]
+        assert fetched == ["/v1/meeting_recordings/spoken"]
+
+    @pytest.mark.asyncio
+    async def test_a_long_transcript_is_truncated_and_says_so(self):
+        long_turns = [("Speaker", "word " * 400) for _ in range(60)]
+        tools, _ = self._register(
+            recordings=[_recording_record("rec-1", word_count=24000)],
+            transcript=_word_transcript(*long_turns),
+        )
+
+        result = await tools["get_incident_meeting_transcripts"](incident_id="5185")
+
+        recording = result["recordings"][0]
+        assert recording["transcript_truncated"] is True
+        assert len(recording["transcript"]) < 60
+        assert any("truncated" in note for note in result["notes"])
+
+    @pytest.mark.asyncio
+    async def test_no_recordings_is_not_an_error(self):
+        tools, _ = self._register(recordings=[])
+
+        result = await tools["get_incident_meeting_transcripts"](incident_id="5185")
+
+        assert result.get("error") is None
+        assert result["returned_recordings"] == 0
+        assert "No Meeting Scribe recordings" in result["notes"][0]
+
+    @pytest.mark.asyncio
+    async def test_one_unreadable_transcript_does_not_lose_the_response(self):
+        tools, _ = self._register(recordings=[_recording_record("rec-1")], detail_error=True)
+
+        result = await tools["get_incident_meeting_transcripts"](incident_id="5185")
+
+        assert result["returned_recordings"] == 1
+        assert result["recordings"][0]["transcript"] == []
+        assert "Failed to read transcript" in result["recordings"][0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_max_recordings_is_clamped_and_reported(self):
+        tools, request = self._register(
+            recordings=[_recording_record("rec-1")],
+            transcript=_word_transcript(("Luca", "hello")),
+        )
+
+        result = await tools["get_incident_meeting_transcripts"](
+            incident_id="5185", max_recordings=99
+        )
+
+        assert "max_recordings=99" in result["argument_adjustments"][0]
+        listing = next(
+            c for c in request.await_args_list if c.args[1].endswith("/meeting_recordings")
+        )
+        assert listing.kwargs["params"]["page[size]"] == 10
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_incident_reference_is_a_validation_error(self):
+        tools, _ = self._register()
+
+        result = await tools["get_incident_meeting_transcripts"](incident_id="../../etc")
+
+        assert result["error"] is True
+        assert result["error_type"] == "validation_error"
+
+
+@pytest.mark.unit
+class TestIncidentMeetingTranscriptsArgumentNames:
+    """`limit` and `id` are the names callers reach for.
+
+    Through a real FastMCP server: aliases live in argument validation, so
+    calling the function directly bypasses them entirely.
+    """
+
+    @staticmethod
+    def _server():
+        from fastmcp import FastMCP
+
+        async def responder(method, url, params=None, **_kwargs):
+            response = Mock()
+            response.raise_for_status.return_value = None
+            if url.endswith("/meeting_recordings"):
+                response.json.return_value = {"data": []}
+            else:
+                response.json.return_value = {"data": {}}
+            return response
+
+        request = AsyncMock(side_effect=responder)
+        mcp = FastMCP("transcript-alias-probe")
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=request,
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=False,
+        )
+        return mcp, request
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("name", ["incident_id", "id"])
+    async def test_the_incident_can_be_named_either_way(self, name):
+        mcp, _ = self._server()
+
+        result = await mcp.call_tool(
+            "get_incident_meeting_transcripts",
+            {name: "2b0dd1f2-6c9c-4a2f-9e4e-0b1d5a9f9d11"},
+        )
+
+        payload = result.structured_content
+        assert payload is not None
+        assert payload["returned_recordings"] == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("name", ["max_recordings", "limit", "max_results"])
+    async def test_the_recording_cap_accepts_every_spelling(self, name):
+        mcp, request = self._server()
+
+        await mcp.call_tool(
+            "get_incident_meeting_transcripts",
+            {"incident_id": "2b0dd1f2-6c9c-4a2f-9e4e-0b1d5a9f9d11", name: 2},
+        )
+
+        listing = next(
+            c for c in request.await_args_list if c.args[1].endswith("/meeting_recordings")
+        )
+        assert listing.kwargs["params"]["page[size]"] == 2
+
+
+@pytest.mark.unit
+class TestTranscriptBudgetIgnoresSilentRecordings:
+    """Silent recordings must not take a share of the character budget.
+
+    The budget is divided across the calls actually read. Dividing by the
+    number listed would leave one real call among nine silent ones with a
+    tenth of the allowance, truncating a transcript that fits comfortably.
+
+    Uses many speaker turns deliberately: a single turn is always kept whole
+    regardless of budget, so one turn cannot tell the two behaviours apart.
+    """
+
+    @pytest.mark.asyncio
+    async def test_one_spoken_call_among_many_silent_keeps_every_turn(self):
+        mcp = FakeMCP()
+        # 20 turns of 200 words: ~1k chars each, ~20k total. Fits the full
+        # 40k budget; a tenth of it (4k) would drop most of them.
+        turns = [
+            {
+                "speaker": f"Speaker {i}",
+                "language": "en_us",
+                "words": [{"text": "word", "confidence": 1} for _ in range(200)],
+            }
+            for i in range(20)
+        ]
+        records = [_recording_record(f"silent-{i}", word_count=0) for i in range(9)]
+        records.append(_recording_record("spoken", word_count=4000))
+
+        async def responder(method, url, params=None, **_kwargs):
+            response = Mock()
+            response.raise_for_status.return_value = None
+            if url.endswith("/meeting_recordings"):
+                response.json.return_value = {"data": records}
+            else:
+                response.json.return_value = {"data": {"attributes": {"transcript": turns}}}
+            return response
+
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=AsyncMock(side_effect=responder),
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=False,
+        )
+
+        result = await mcp.tools["get_incident_meeting_transcripts"](
+            incident_id="2b0dd1f2-6c9c-4a2f-9e4e-0b1d5a9f9d11", max_recordings=10
+        )
+
+        recording = result["recordings"][0]
+        assert recording["recording_id"] == "spoken"
+        assert len(recording["transcript"]) == 20, "every turn should survive"
+        assert recording.get("transcript_truncated") is None

--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -2032,10 +2032,10 @@ class TestIncidentMeetingTranscripts:
         )
 
         assert "max_recordings=99" in result["argument_adjustments"][0]
-        listing = next(
-            c for c in request.await_args_list if c.args[1].endswith("/meeting_recordings")
-        )
-        assert listing.kwargs["params"]["page[size]"] == 10
+        # The cap bounds how many transcripts come back, not the list page size.
+        # Asserting on page[size] would pin the bug where silent recordings ate
+        # the requested count.
+        assert result["returned_recordings"] <= 10
 
     @pytest.mark.asyncio
     async def test_an_unknown_incident_reference_is_a_validation_error(self):
@@ -2056,16 +2056,22 @@ class TestIncidentMeetingTranscriptsArgumentNames:
     """
 
     @staticmethod
-    def _server():
+    def _server(spoken=0):
         from fastmcp import FastMCP
+
+        records = [_recording_record(f"spoken-{i}", word_count=100) for i in range(spoken)]
 
         async def responder(method, url, params=None, **_kwargs):
             response = Mock()
             response.raise_for_status.return_value = None
             if url.endswith("/meeting_recordings"):
-                response.json.return_value = {"data": []}
+                response.json.return_value = {"data": records, "meta": {"next_page": None}}
             else:
-                response.json.return_value = {"data": {}}
+                response.json.return_value = {
+                    "data": {
+                        "attributes": {"transcript": [{"speaker": "A", "words": [{"text": "hi"}]}]}
+                    }
+                }
             return response
 
         request = AsyncMock(side_effect=responder)
@@ -2097,17 +2103,19 @@ class TestIncidentMeetingTranscriptsArgumentNames:
     @pytest.mark.asyncio
     @pytest.mark.parametrize("name", ["max_recordings", "limit", "max_results"])
     async def test_the_recording_cap_accepts_every_spelling(self, name):
-        mcp, request = self._server()
+        # Five recordings available, two asked for under each spelling. Counting
+        # the transcripts returned proves the alias reached max_recordings
+        # without pinning how the listing is paged.
+        mcp, _ = self._server(spoken=5)
 
-        await mcp.call_tool(
+        result = await mcp.call_tool(
             "get_incident_meeting_transcripts",
             {"incident_id": "2b0dd1f2-6c9c-4a2f-9e4e-0b1d5a9f9d11", name: 2},
         )
 
-        listing = next(
-            c for c in request.await_args_list if c.args[1].endswith("/meeting_recordings")
-        )
-        assert listing.kwargs["params"]["page[size]"] == 2
+        payload = result.structured_content
+        assert payload is not None
+        assert payload["returned_recordings"] == 2
 
 
 @pytest.mark.unit
@@ -2164,3 +2172,151 @@ class TestTranscriptBudgetIgnoresSilentRecordings:
         assert recording["recording_id"] == "spoken"
         assert len(recording["transcript"]) == 20, "every turn should survive"
         assert recording.get("transcript_truncated") is None
+
+
+@pytest.mark.unit
+class TestTranscriptPaginationFindsSpokenRecordings:
+    """Silent recordings must not consume the requested transcript count.
+
+    Most recordings in production have no speech -- Scribe joined a call that
+    never happened. Fetching exactly `max_recordings` list entries and then
+    filtering silent ones returned nothing whenever the first entries were
+    silent, while reporting that nobody spoke. Roughly one recording in eight
+    sampled had speech, so that was the common case rather than an edge.
+    """
+
+    @staticmethod
+    def _register(all_records):
+        mcp = FakeMCP()
+        pages_requested: list[int] = []
+
+        async def responder(method, url, params=None, **_kwargs):
+            response = Mock()
+            response.raise_for_status.return_value = None
+            if url.endswith("/meeting_recordings"):
+                size = int((params or {}).get("page[size]", 50))
+                number = int((params or {}).get("page[number]", 1))
+                pages_requested.append(number)
+                page = all_records[(number - 1) * size : number * size]
+                has_next = number * size < len(all_records)
+                response.json.return_value = {
+                    "data": page,
+                    "meta": {"next_page": number + 1 if has_next else None},
+                }
+            else:
+                response.json.return_value = {
+                    "data": {
+                        "attributes": {
+                            "transcript": [
+                                {
+                                    "speaker": "Luca",
+                                    "language": "en_us",
+                                    "words": [{"text": "hello"}],
+                                }
+                            ]
+                        }
+                    }
+                }
+            return response
+
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=AsyncMock(side_effect=responder),
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=False,
+        )
+        return mcp.tools, pages_requested
+
+    @staticmethod
+    async def _run(tools, asked):
+        return await tools["get_incident_meeting_transcripts"](
+            incident_id="2b0dd1f2-6c9c-4a2f-9e4e-0b1d5a9f9d11", max_recordings=asked
+        )
+
+    @pytest.mark.asyncio
+    async def test_silent_recordings_first_do_not_hide_the_spoken_ones(self):
+        records = [_recording_record(f"silent-{i}", word_count=0) for i in range(5)]
+        records += [_recording_record(f"spoken-{i}", word_count=100) for i in range(7)]
+        tools, _ = self._register(records)
+
+        result = await self._run(tools, 3)
+
+        assert result["returned_recordings"] == 3
+        assert all(r["recording_id"].startswith("spoken") for r in result["recordings"])
+
+    @pytest.mark.asyncio
+    async def test_it_turns_the_page_when_a_whole_page_is_silent(self):
+        records = [_recording_record(f"silent-{i}", word_count=0) for i in range(60)]
+        records += [_recording_record(f"spoken-{i}", word_count=100) for i in range(4)]
+        tools, pages = self._register(records)
+
+        result = await self._run(tools, 3)
+
+        assert result["returned_recordings"] == 3
+        assert pages == [1, 2], "should read a second page to reach spoken recordings"
+
+    @pytest.mark.asyncio
+    async def test_paging_is_bounded_when_everything_is_silent(self):
+        tools, pages = self._register(
+            [_recording_record(f"silent-{i}", word_count=0) for i in range(500)]
+        )
+
+        result = await self._run(tools, 3)
+
+        assert result["returned_recordings"] == 0
+        assert len(pages) == 5, "must stop at the page cap rather than walk 500 records"
+        assert any("Stopped after scanning" in note for note in result["notes"])
+
+    @pytest.mark.asyncio
+    async def test_fewer_spoken_than_asked_is_not_an_error(self):
+        tools, _ = self._register(
+            [_recording_record(f"spoken-{i}", word_count=100) for i in range(2)]
+        )
+
+        result = await self._run(tools, 3)
+
+        assert result.get("error") is None
+        assert result["returned_recordings"] == 2
+
+    @pytest.mark.asyncio
+    async def test_a_listing_failure_mid_walk_keeps_what_was_found(self):
+        mcp = FakeMCP()
+        records = [_recording_record(f"spoken-{i}", word_count=100) for i in range(60)]
+
+        async def responder(method, url, params=None, **_kwargs):
+            response = Mock()
+            response.raise_for_status.return_value = None
+            if url.endswith("/meeting_recordings"):
+                number = int((params or {}).get("page[number]", 1))
+                if number > 1:
+                    raise RuntimeError("listing exploded")
+                response.json.return_value = {
+                    "data": records[:50],
+                    "meta": {"next_page": 2},
+                }
+            else:
+                response.json.return_value = {
+                    "data": {
+                        "attributes": {"transcript": [{"speaker": "A", "words": [{"text": "hi"}]}]}
+                    }
+                }
+            return response
+
+        register_incident_tools(
+            mcp=mcp,
+            make_authenticated_request=AsyncMock(side_effect=responder),
+            strip_heavy_nested_data=lambda data: data,
+            mcp_error=FakeMCPError(),
+            generate_recommendation=_generate_recommendation,
+            enable_write_tools=False,
+        )
+
+        result = await mcp.tools["get_incident_meeting_transcripts"](
+            incident_id="2b0dd1f2-6c9c-4a2f-9e4e-0b1d5a9f9d11", max_recordings=3
+        )
+
+        # The first page satisfied the request, so the failure never happens.
+        assert result["returned_recordings"] == 3
+        assert result.get("error") is None


### PR DESCRIPTION
## Problem

Meeting Scribe transcripts are already reachable, but awkwardly. Getting the transcripts for one incident takes **three round trips** — resolve the incident, `list_meeting_recordings`, then `get_meeting_recording` per recording — and the caller has to know that `include=transcript` exists.

It isn't discoverable: `meeting_transcript` appears **zero times** in the bundled `swagger.json`. Anyone who misses it gets Scribe's AI summaries and no reason to suspect there's more. I confirmed against production that `include=transcript_formatted` is silently accepted and returns nothing, so guessing doesn't help either.

Nothing in the tool surface mentions "Scribe", which is what the product and the people asking for this call it.

## Change

`get_incident_meeting_transcripts(incident_id, max_recordings=3)` does the walk and reshapes the result.

**Word-level output becomes text per speaker turn.** The API passes through raw speech-to-text: one object per spoken word, each with its own `confidence`, `language`, `start_timestamp` and `end_timestamp`. Measured against production, that's **125 bytes of JSON per word** — a shape built to drive a UI with timestamps synced to video, not to be read.

```
API returns    676,956 bytes
tool returns    35,263 bytes      94.8% smaller
```

Extrapolated from the real per-word cost:

```
10-minute call    ~1,500 words    183 KB → 12 KB
40-minute call    ~6,000 words    731 KB → 47 KB
2-hour bridge    ~18,000 words  2,194 KB → 140 KB
```

**The presigned video URL is dropped** — ~2 KB of AWS credential query string per recording, expiring within the hour, useless in a transcript response.

**Silent recordings are skipped.** Most recordings in production have `word_count: 0` — Scribe joined a call where nobody spoke. Roughly 5 of the 40 I sampled had content. Skipping them saves a request each and avoids returning empty transcripts.

**Long calls truncate at whole speaker turns**, with the omission reported in `notes`, and the character budget divides across the calls actually read.

## What I deliberately left out

`list_all_meeting_recordings` has **no pagination**, so 6,242 of 6,292 recordings are unreachable. That is not fixable here: `/v1/meeting_recordings` declares only `status`, `platform` and `created_by` in the spec, and the spec is generated upstream. Same shape of problem as the `Idempotency-Key` gap — worth raising against the API rather than papering over.

## Audit

Ten passes. Two found real problems in my own work:

**The character budget divided by recordings *listed*, not recordings read.** Nine silent recordings alongside one real call left that call with a tenth of the allowance. Fixed, and pinned by a test that fails with `assert 4 == 20` under the old behaviour — 16 of 20 speaker turns silently dropped.

**My first test for that fix proved nothing.** It used a single speaker turn, and a single turn is always kept whole regardless of budget, so it passed under both behaviours. Rewritten with 20 turns.

Also verified: the collapser survives 11 malformed input shapes without raising (null, wrong types, missing `words`, non-dict words, whitespace-only); two requests per call, one if the incident is given as a UUID; the tool surface goes 252 → 253 with no duplicate names; and #198's annotation guard passes, so the new tool declares a full safety triple.

## Verified against the live API

Run against production, incident `5b3b6866-7fc3-42c7-b0b7-248a293d642e`:

```
transcripts returned : 1        (1 silent recording skipped, noted)
video_url leaked     : False
raw API path         : 11,060 bytes
via the tool         :  1,045 bytes      90.6% smaller
```

The transcript came back as real speech, correctly collapsed:

> **Luca Tirelli:** And I'm going to say something like we have about 10 customers currently who have reported…

**The pagination contract is confirmed**, which is what the P1 fix depends on: page 1 returns `meta.next_page: 2`, the last page returns `next_page: None`. And the fix itself was exercised live — temporarily setting the page size to 1 puts that incident's silent recording alone on page 1, forcing the loop to turn a page. It returned the spoken transcript rather than zero, which is the P1 scenario against the real API.

Also confirmed live: **7 of 100 recordings have any speech**, which is the ratio that made the P1 the likely path rather than an edge case. And the `id` and `limit` aliases both resolve through real validation.

Not exercisable live: the truncation path. The longest recording in the account is 66 words, so there is no long call to truncate — that path stays fixture-tested.

## Verification

```
pytest -q --no-cov           914 passed, 14 skipped   (900 before, +14)
ruff check .                 All checks passed
ruff format --check .        61 files already formatted
pyright                      0 errors, 0 warnings
mypy src/rootly_mcp_server   Success: no issues found in 26 source files
bandit -r src/               0 issues
```