### PR TITLE
Add list_audits for reading the Rootly audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`list_audits` reads the Rootly audit log**: who changed which configuration object, when, from where, and the before-and-after value of every modified field. Filters by `item_type`, user, API key, source and a `created_at` range. Two behaviours of the underlying endpoint are handled rather than passed through: a `404` is reported as the missing `Audits - read` role permission rather than as a missing record, and an empty result is annotated, because `filter[item_type]` accepts any value and silently matches nothing so a typo and "nothing changed" would otherwise be indistinguishable. Records are size-bounded and the full object state is opt-in.
+
 ### Fixed
 
 - **`rootly://workflow-guide` and the example incident-responder skill name tools by their advertised `snake_case` names**: both still used the historical camelCase operationIds (`createIncident`, `listIncidentAlerts`, `getScheduleShifts`, …). Those names remain callable through the alias middleware but are hidden from `tools/list`, so the guidance pointed the model at tools it could not see. A unit test now fails if either document references a tool that is not advertised.

--- a/src/rootly_mcp_server/server.py
+++ b/src/rootly_mcp_server/server.py
@@ -24,6 +24,7 @@ from .exceptions import RootlyAuthenticationError
 from .mcp_error import MCPError
 from .security import mask_sensitive_data, sanitize_error_message
 from .tools.alerts import register_alert_tools
+from .tools.audits import register_audit_tools
 from .tools.incidents import register_incident_tools
 from .tools.oncall import register_oncall_tools
 from .tools.resources import register_resource_handlers
@@ -1036,6 +1037,12 @@ def create_rootly_mcp_server(
     )
 
     register_alert_tools(
+        mcp=mcp,
+        make_authenticated_request=make_authenticated_request,
+        mcp_error=MCPError,
+    )
+
+    register_audit_tools(
         mcp=mcp,
         make_authenticated_request=make_authenticated_request,
         mcp_error=MCPError,

--- a/src/rootly_mcp_server/tools/__init__.py
+++ b/src/rootly_mcp_server/tools/__init__.py
@@ -1,12 +1,14 @@
 """Tool registration modules for Rootly MCP server."""
 
 from .alerts import register_alert_tools
+from .audits import register_audit_tools
 from .incidents import register_incident_tools
 from .oncall import register_oncall_tools
 from .resources import register_resource_handlers
 
 __all__ = [
     "register_alert_tools",
+    "register_audit_tools",
     "register_incident_tools",
     "register_oncall_tools",
     "register_resource_handlers",

--- a/src/rootly_mcp_server/tools/audits.py
+++ b/src/rootly_mcp_server/tools/audits.py
@@ -1,0 +1,376 @@
+"""Audit log tool registration for Rootly MCP server."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Annotated, Any, Protocol
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+JsonDict = dict[str, Any]
+MakeAuthenticatedRequest = Callable[..., Awaitable[Any]]
+
+ADJUSTMENTS_KEY = "argument_adjustments"
+
+MAX_RESULTS_CEILING = 25
+DEFAULT_MAX_RESULTS = 10
+# Each record can carry a large `object` (full object state) and
+# `object_changes` (before/after per field). Long values are trimmed so a
+# page of records cannot crowd out the rest of a conversation.
+VALUE_CHARS = 200
+CHANGED_FIELDS_SHOWN = 25
+OBJECT_FIELDS_SHOWN = 40
+
+# Resource types the API documents for filter[item_type]. Used only to warn
+# when a filter returns nothing: an unrecognised item_type is accepted and
+# silently matches zero records, which reads identically to "nothing changed".
+# Never used to reject input, so a newly instrumented type still works.
+KNOWN_ITEM_TYPES = frozenset(
+    {
+        "AlertRoute",
+        "AlertRoutingRule",
+        "Alerts::Source",
+        "ApiKey",
+        "Catalog",
+        "CatalogEntity",
+        "CatalogEntityProperty",
+        "CatalogField",
+        "Cause",
+        "CustomField",
+        "CustomFieldOption",
+        "CustomForm",
+        "Dashboard",
+        "EdgeConnector",
+        "EdgeConnector::Action",
+        "Environment",
+        "EscalationPolicy",
+        "EscalationPolicyPath",
+        "ExportJob",
+        "FormField",
+        "Functionality",
+        "GeniusWorkflow",
+        "GeniusWorkflowGroup",
+        "GeniusWorkflowRun",
+        "Group",
+        "GroupUser",
+        "Heartbeat",
+        "Incident",
+        "IncidentActionItem",
+        "IncidentEvent",
+        "IncidentFormFieldSelection",
+        "IncidentFormFieldSelectionUser",
+        "IncidentPermissionSet",
+        "IncidentPostMortem",
+        "IncidentRoleAssignment",
+        "IncidentRoleTask",
+        "IncidentStatusPageEvent",
+        "IncidentTask",
+        "IncidentType",
+        "Integrations::DatadogAccount",
+        "Integrations::GithubAccount",
+        "Integrations::GoogleMeetAccount",
+        "Integrations::JiraAccount",
+        "Integrations::MicrosoftTeamsAccount",
+        "Integrations::NotionAccount",
+        "Integrations::OpsgenieAccount",
+        "Integrations::PagerdutyAccount",
+        "Integrations::ServiceNowAccount",
+        "Integrations::SlackAccount",
+        "Integrations::StatusPageIoAccount",
+        "Integrations::ZendeskAccount",
+        "Integrations::ZoomAccount",
+        "LiveCallRouter",
+        "LoginActivity",
+        "Membership",
+        "OnCallRole",
+        "Playbook",
+        "PlaybookTask",
+        "Role",
+        "Schedule",
+        "Secret",
+        "Service",
+        "Severity",
+        "StatusPage",
+    }
+)
+
+# Configuration lives in child records for these types, and those children are
+# not instrumented: filtering for them returns zero rows, and the parent's
+# object_changes carries only the parent's own columns. Verified against
+# production. Callers asking about them are told so rather than being handed an
+# empty result to misread.
+UNAUDITED_CHILD_TYPES = {
+    "ScheduleRotation": "Schedule",
+    "ScheduleRotationUser": "Schedule",
+    "ScheduleRotationActiveDay": "Schedule",
+    "Shift": "Schedule",
+    "OverrideShift": "Schedule",
+    "EscalationLevel": "EscalationPolicy",
+    "GeniusWorkflowTask": "GeniusWorkflow",
+    "WorkflowTask": "GeniusWorkflow",
+}
+
+
+class MCPErrorLike(Protocol):
+    """Protocol for MCP error helpers used by audit tools."""
+
+    @staticmethod
+    def tool_error(
+        error_message: str,
+        error_type: str = "execution_error",
+        details: dict[str, Any] | None = None,
+    ) -> JsonDict: ...
+
+    @staticmethod
+    def categorize_error(exception: Exception) -> tuple[str, str]: ...
+
+
+def _clamp(name: str, value: int, notes: list[str], *, minimum: int, maximum: int) -> int:
+    used = max(minimum, min(maximum, value))
+    if used != value:
+        notes.append(f"{name}={value} is outside the supported range; used {used} instead.")
+    return used
+
+
+def _trim(value: Any) -> Any:
+    """Shorten long scalars so one verbose field cannot dominate the result."""
+    if isinstance(value, str) and len(value) > VALUE_CHARS:
+        return value[:VALUE_CHARS] + f"... [{len(value)} chars]"
+    if isinstance(value, dict | list):
+        rendered = str(value)
+        if len(rendered) > VALUE_CHARS:
+            return rendered[:VALUE_CHARS] + f"... [{len(rendered)} chars]"
+    return value
+
+
+def _trim_object(value: Any) -> Any:
+    """Bound an object's size without collapsing it into a string.
+
+    `_trim` stringifies a large dict, which is the wrong answer for a caller
+    that explicitly asked for structured object state. Each field is trimmed
+    individually instead, and the field count is capped, so the result stays a
+    mapping the caller can read.
+    """
+    if not isinstance(value, dict):
+        return _trim(value)
+    trimmed: JsonDict = {}
+    for key in list(value)[:OBJECT_FIELDS_SHOWN]:
+        trimmed[key] = _trim(value[key])
+    omitted = len(value) - len(trimmed)
+    if omitted > 0:
+        trimmed["_fields_omitted"] = omitted
+    return trimmed
+
+
+def _summarize_changes(object_changes: Any) -> tuple[JsonDict, int]:
+    """Render object_changes as field -> {from, to}, trimmed and capped."""
+    if not isinstance(object_changes, dict):
+        return {}, 0
+    # PaperTrail records each field as [before, after]; humanized payloads may
+    # already be a mapping. Both shapes are handled.
+    summary: JsonDict = {}
+    for field, change in list(object_changes.items())[:CHANGED_FIELDS_SHOWN]:
+        if isinstance(change, list) and len(change) == 2:
+            summary[field] = {"from": _trim(change[0]), "to": _trim(change[1])}
+        elif isinstance(change, dict) and ("from" in change or "to" in change):
+            summary[field] = {
+                "from": _trim(change.get("from")),
+                "to": _trim(change.get("to")),
+            }
+        else:
+            summary[field] = _trim(change)
+    return summary, len(object_changes)
+
+
+def register_audit_tools(
+    mcp: Any,
+    make_authenticated_request: MakeAuthenticatedRequest,
+    mcp_error: MCPErrorLike,
+) -> None:
+    """Register audit log tools on the MCP server."""
+
+    @mcp.tool(
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=True,
+        ),
+    )
+    async def list_audits(
+        item_type: Annotated[
+            str,
+            Field(
+                description=(
+                    "Restrict to one resource type, e.g. 'Schedule', 'GeniusWorkflow', "
+                    "'EscalationPolicy', 'ApiKey', 'Role', 'Membership'. Leave blank "
+                    "for every type."
+                )
+            ),
+        ] = "",
+        user_id: Annotated[
+            str,
+            Field(description="Only changes made by this Rootly user ID."),
+        ] = "",
+        api_key_id: Annotated[
+            str,
+            Field(description="Only changes made with this API key ID."),
+        ] = "",
+        source: Annotated[
+            str,
+            Field(
+                description=(
+                    "Where the change came from: 'web', 'api', 'mobile', 'slack', "
+                    "'scim' or 'oauth'."
+                )
+            ),
+        ] = "",
+        since: Annotated[
+            str,
+            Field(description="Only changes at or after this ISO 8601 timestamp or date."),
+        ] = "",
+        until: Annotated[
+            str,
+            Field(description="Only changes at or before this ISO 8601 timestamp or date."),
+        ] = "",
+        max_results: Annotated[
+            int,
+            Field(description=f"Maximum records to return. Max: {MAX_RESULTS_CEILING}."),
+        ] = DEFAULT_MAX_RESULTS,
+        include_full_object: Annotated[
+            bool,
+            Field(
+                description=(
+                    "Include each record's full object state alongside the diff. "
+                    "Off by default because it is the bulk of the payload."
+                )
+            ),
+        ] = False,
+    ) -> JsonDict:
+        """Read the Rootly audit log: who changed which configuration object, when, and what changed.
+
+        Each record carries the action, the acting user, the source, and the
+        before-and-after value of every modified field. Use it to answer "who
+        changed this escalation policy", "what did this workflow look like
+        before", or to collect change evidence for a compliance review.
+
+        Covers roughly 60 resource types at the object level and is retained
+        indefinitely. Two limits worth knowing: schedule rotations, escalation
+        levels and shift overrides are not audited, and sign-in events are kept
+        separately from this log.
+
+        Returns a single page of at most 25 records, newest first, alongside
+        `total_matching` so a wider search can be narrowed with the filters. It
+        does not walk the whole log, so a full compliance export belongs on the
+        REST endpoint rather than here.
+
+        Requires an API token whose role has the "Audits - read" permission.
+        """
+        notes: list[str] = []
+        try:
+            capped = _clamp(
+                "max_results", max_results, notes, minimum=1, maximum=MAX_RESULTS_CEILING
+            )
+
+            params: dict[str, Any] = {
+                "page[size]": capped,
+                "page[number]": 1,
+            }
+            requested_type = item_type.strip()
+            if requested_type:
+                params["filter[item_type]"] = requested_type
+            if user_id.strip():
+                params["filter[user_id]"] = user_id.strip()
+            if api_key_id.strip():
+                params["filter[api_key_id]"] = api_key_id.strip()
+            if source.strip():
+                params["filter[source]"] = source.strip().lower()
+            if since.strip():
+                params["filter[created_at][gte]"] = since.strip()
+            if until.strip():
+                params["filter[created_at][lte]"] = until.strip()
+
+            response = await make_authenticated_request("GET", "/v1/audits", params=params)
+
+            # This endpoint answers 404 for a role without audit access as well
+            # as for a genuinely missing record, so the bare status would send
+            # callers looking for a feature that is present but not permitted.
+            if response.status_code == 404:
+                return mcp_error.tool_error(
+                    "Cannot read the audit log. This endpoint returns 404 both when "
+                    "a record is missing and when the token's role lacks audit "
+                    "access, and the latter is the usual cause. Enable the "
+                    "'Audits - read' permission on the role under Configuration -> "
+                    "Roles & Permissions, or use a token whose role already has it.",
+                    "permission_error",
+                )
+            response.raise_for_status()
+
+            body = response.json() or {}
+            records = body.get("data") or []
+            meta = body.get("meta") or {}
+
+            audits: list[JsonDict] = []
+            for record in records[:capped]:
+                attrs = record.get("attributes") or {}
+                changes, total_changed = _summarize_changes(attrs.get("object_changes"))
+                entry: JsonDict = {
+                    "id": record.get("id"),
+                    "occurred_at": attrs.get("created_at"),
+                    "action": attrs.get("event"),
+                    "item_type": attrs.get("item_type"),
+                    "item_type_display": attrs.get("item_type_display"),
+                    "item_id": attrs.get("item_id"),
+                    "actor": {
+                        "user_id": attrs.get("user_id"),
+                        "name": attrs.get("user_name"),
+                        "email": attrs.get("user_email"),
+                    },
+                    "source": attrs.get("source"),
+                    "changed_fields": changes,
+                }
+                if total_changed > len(changes):
+                    entry["changed_fields_omitted"] = total_changed - len(changes)
+                for optional in ("ip_address", "user_agent", "request_id"):
+                    if attrs.get(optional):
+                        entry[optional] = attrs[optional]
+                if include_full_object:
+                    entry["object"] = _trim_object(attrs.get("object"))
+                audits.append(entry)
+
+            result: JsonDict = {
+                "audits": audits,
+                "returned": len(audits),
+                "total_matching": meta.get("total_count"),
+            }
+
+            # An unrecognised item_type is accepted and matches nothing, so an
+            # empty result is ambiguous without saying which case it was.
+            if not audits and requested_type:
+                if requested_type in UNAUDITED_CHILD_TYPES:
+                    parent = UNAUDITED_CHILD_TYPES[requested_type]
+                    result["note"] = (
+                        f"'{requested_type}' is not audited, so this is not evidence that "
+                        f"nothing changed. Changes to it are not recorded under its own "
+                        f"type, and its parent '{parent}' records only the parent's own "
+                        f"fields. Auditing the underlying configuration change is not "
+                        f"currently possible through this log."
+                    )
+                elif requested_type not in KNOWN_ITEM_TYPES:
+                    result["note"] = (
+                        f"No records matched, and '{requested_type}' is not one of the "
+                        f"item_types this tool knows about. The filter accepts any value "
+                        f"and silently matches nothing, so this may be a misspelling "
+                        f"(values are CamelCase model names such as 'Schedule' or "
+                        f"'GeniusWorkflow') or a type added since this list was written "
+                        f"— either way, do not read it as no changes."
+                    )
+
+            if notes:
+                result[ADJUSTMENTS_KEY] = notes
+            return result
+
+        except Exception as e:
+            error_type, error_message = mcp_error.categorize_error(e)
+            return mcp_error.tool_error(f"Failed to list audits: {error_message}", error_type)

--- a/tests/unit/test_audits_tool.py
+++ b/tests/unit/test_audits_tool.py
@@ -1,0 +1,269 @@
+"""Tests for the curated list_audits tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from rootly_mcp_server.tools.audits import register_audit_tools
+
+
+class FakeMCP:
+    """Small tool registry used for direct custom tool testing."""
+
+    def __init__(self) -> None:
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, name: str | None = None, **_: Any):
+        def decorator(fn):
+            self.tools[name or fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+class FakeMCPError:
+    @staticmethod
+    def categorize_error(exception: Exception) -> tuple[str, str]:
+        return (exception.__class__.__name__, str(exception))
+
+    @staticmethod
+    def tool_error(
+        error_message: str,
+        error_type: str = "execution_error",
+        details: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        # Parameter names must match the MCPErrorLike protocol, not just types.
+        return {"error": True, "error_type": error_type, "message": error_message}
+
+
+class FakeResponse:
+    def __init__(self, payload: Any, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+def _audit(**overrides: Any) -> dict[str, Any]:
+    attrs = {
+        "created_at": "2026-09-03T12:00:00Z",
+        "event": "update",
+        "item_type": "Schedule",
+        "item_type_display": "Schedule",
+        "item_id": "sched-1",
+        "user_id": 42,
+        "user_name": "Ada Lovelace",
+        "user_email": "ada@example.com",
+        "source": "web",
+        "object_changes": {"name": ["Old name", "New name"]},
+    }
+    attrs.update(overrides)
+    return {"id": "1", "type": "audits", "attributes": attrs}
+
+
+def _build(response: FakeResponse | list[FakeResponse]):
+    """Register the tool against a fake request function, capturing calls."""
+    calls: list[dict[str, Any]] = []
+    responses = response if isinstance(response, list) else [response]
+
+    async def make_request(method: str, path: str, **kwargs: Any):
+        calls.append({"method": method, "path": path, **kwargs})
+        return responses[min(len(calls) - 1, len(responses) - 1)]
+
+    mcp = FakeMCP()
+    register_audit_tools(mcp=mcp, make_authenticated_request=make_request, mcp_error=FakeMCPError)
+    return mcp.tools["list_audits"], calls
+
+
+@pytest.mark.unit
+class TestListAuditsHappyPath:
+    @pytest.mark.asyncio
+    async def test_summarizes_records_and_reports_totals(self):
+        tool, calls = _build(
+            FakeResponse({"data": [_audit(), _audit()], "meta": {"total_count": 759}})
+        )
+        result = await tool()
+
+        assert result["returned"] == 2
+        assert result["total_matching"] == 759
+        first = result["audits"][0]
+        assert first["action"] == "update"
+        assert first["item_type"] == "Schedule"
+        assert first["actor"]["email"] == "ada@example.com"
+        assert calls[0]["path"] == "/v1/audits"
+
+    @pytest.mark.asyncio
+    async def test_paper_trail_pairs_become_from_and_to(self):
+        tool, _ = _build(FakeResponse({"data": [_audit()], "meta": {}}))
+        result = await tool()
+        assert result["audits"][0]["changed_fields"] == {
+            "name": {"from": "Old name", "to": "New name"}
+        }
+
+    @pytest.mark.asyncio
+    async def test_filters_are_forwarded_as_api_params(self):
+        tool, calls = _build(FakeResponse({"data": [], "meta": {}}))
+        await tool(
+            item_type="GeniusWorkflow",
+            user_id="42",
+            api_key_id="key-1",
+            source="API",
+            since="2026-08-01",
+            until="2026-09-01",
+        )
+        params = calls[0]["params"]
+        assert params["filter[item_type]"] == "GeniusWorkflow"
+        assert params["filter[user_id]"] == "42"
+        assert params["filter[api_key_id]"] == "key-1"
+        # source is normalised; the API expects the lowercase form
+        assert params["filter[source]"] == "api"
+        assert params["filter[created_at][gte]"] == "2026-08-01"
+        assert params["filter[created_at][lte]"] == "2026-09-01"
+
+    @pytest.mark.asyncio
+    async def test_full_object_is_opt_in(self):
+        payload = {"data": [_audit(object={"name": "New name"})], "meta": {}}
+        tool, _ = _build(FakeResponse(payload))
+        assert "object" not in (await tool())["audits"][0]
+
+        tool, _ = _build(FakeResponse(payload))
+        assert "object" in (await tool(include_full_object=True))["audits"][0]
+
+
+@pytest.mark.unit
+class TestListAuditsPermissionError:
+    """A 404 here almost always means the role lacks audit access."""
+
+    @pytest.mark.asyncio
+    async def test_404_explains_the_permission_rather_than_reporting_not_found(self):
+        tool, _ = _build(FakeResponse({}, status_code=404))
+        result = await tool()
+
+        assert result["error"] is True
+        assert result["error_type"] == "permission_error"
+        assert "Audits - read" in result["message"]
+        # The caller must not be told the feature is absent.
+        assert "not found" not in result["message"].lower().replace("returns 404 both when", "")
+
+
+@pytest.mark.unit
+class TestListAuditsEmptyResultIsExplained:
+    """An empty page is ambiguous: the filter accepts anything and matches nothing."""
+
+    @pytest.mark.asyncio
+    async def test_unaudited_child_type_is_called_out(self):
+        tool, _ = _build(FakeResponse({"data": [], "meta": {"total_count": 0}}))
+        result = await tool(item_type="ScheduleRotation")
+
+        assert result["returned"] == 0
+        assert "not audited" in result["note"]
+        assert "Schedule" in result["note"]
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_item_type_is_flagged_rather_than_read_as_no_changes(self):
+        tool, _ = _build(FakeResponse({"data": [], "meta": {"total_count": 0}}))
+        result = await tool(item_type="scheduleRotationz")
+
+        note = result["note"]
+        # Names the value back, and warns against the wrong conclusion. The
+        # list of known types can go stale, so the note must allow for a
+        # newly added type rather than insisting on a misspelling.
+        assert "scheduleRotationz" in note
+        assert "no changes" in note
+
+    @pytest.mark.asyncio
+    async def test_known_type_with_no_rows_gets_no_misleading_note(self):
+        tool, _ = _build(FakeResponse({"data": [], "meta": {"total_count": 0}}))
+        result = await tool(item_type="Schedule")
+        assert "note" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_note_when_records_were_returned(self):
+        tool, _ = _build(FakeResponse({"data": [_audit()], "meta": {}}))
+        result = await tool(item_type="ScheduleRotation")
+        assert "note" not in result
+
+
+@pytest.mark.unit
+class TestListAuditsArgumentClamping:
+    @pytest.mark.asyncio
+    async def test_oversized_max_results_is_clamped_and_reported(self):
+        tool, calls = _build(FakeResponse({"data": [], "meta": {}}))
+        result = await tool(max_results=500)
+
+        assert "argument_adjustments" in result
+        assert any("max_results=500" in n for n in result["argument_adjustments"])
+        assert calls[0]["params"]["page[size]"] <= 25
+
+    @pytest.mark.asyncio
+    async def test_in_range_max_results_is_not_reported(self):
+        tool, _ = _build(FakeResponse({"data": [], "meta": {}}))
+        assert "argument_adjustments" not in await tool(max_results=5)
+
+    @pytest.mark.asyncio
+    async def test_returns_no_more_than_requested(self):
+        tool, _ = _build(FakeResponse({"data": [_audit() for _ in range(10)], "meta": {}}))
+        result = await tool(max_results=3)
+        assert result["returned"] == 3
+
+
+@pytest.mark.unit
+class TestListAuditsPayloadIsBounded:
+    @pytest.mark.asyncio
+    async def test_long_values_are_trimmed(self):
+        long_value = "x" * 5000
+        tool, _ = _build(
+            FakeResponse(
+                {"data": [_audit(object_changes={"description": [None, long_value]})], "meta": {}}
+            )
+        )
+        result = await tool()
+        rendered = result["audits"][0]["changed_fields"]["description"]["to"]
+        assert len(rendered) < len(long_value)
+        assert "5000 chars" in rendered
+
+    @pytest.mark.asyncio
+    async def test_full_object_stays_structured_when_large(self):
+        # Asked for structured object state, a caller must not receive a
+        # stringified dict; fields are trimmed individually instead.
+        big = {f"field_{i}": f"value_{i}" for i in range(60)}
+        tool, _ = _build(FakeResponse({"data": [_audit(object=big)], "meta": {}}))
+        obj = (await tool(include_full_object=True))["audits"][0]["object"]
+
+        assert isinstance(obj, dict)
+        assert obj["field_0"] == "value_0"
+        assert obj["_fields_omitted"] == 20
+
+    @pytest.mark.asyncio
+    async def test_long_values_inside_the_object_are_trimmed(self):
+        tool, _ = _build(
+            FakeResponse({"data": [_audit(object={"description": "y" * 5000})], "meta": {}})
+        )
+        obj = (await tool(include_full_object=True))["audits"][0]["object"]
+        assert "5000 chars" in obj["description"]
+
+    @pytest.mark.asyncio
+    async def test_many_changed_fields_are_capped_and_the_remainder_counted(self):
+        changes = {f"field_{i}": [i, i + 1] for i in range(60)}
+        tool, _ = _build(FakeResponse({"data": [_audit(object_changes=changes)], "meta": {}}))
+        entry = (await tool())["audits"][0]
+
+        assert len(entry["changed_fields"]) == 25
+        assert entry["changed_fields_omitted"] == 35
+
+
+@pytest.mark.unit
+class TestListAuditsErrorHandling:
+    @pytest.mark.asyncio
+    async def test_upstream_failure_is_reported_not_raised(self):
+        tool, _ = _build(FakeResponse({}, status_code=500))
+        result = await tool()
+        assert result["error"] is True
+        assert "Failed to list audits" in result["message"]


### PR DESCRIPTION
## What this adds

`list_audits` — read the Rootly audit log through the MCP: who changed which configuration object, when, from where, and the before-and-after value of every modified field.

Requested by a customer asking whether audit data and configuration edit history were reachable through the MCP. They were not: `GET /v1/audits` exists and carries everything needed, but the MCP exposed no route to it.

## Why curated rather than an allowlist entry

Adding `"/audits"` to `DEFAULT_ALLOWED_PATHS` is one line, but the generated tool would expose all **28** query parameters — including four operator variants each for `user_id` and `api_key_id`, and four comparators for `created_at`. That is a poor surface to reason about, and the raw records are large enough to crowd out a conversation.

This exposes `item_type`, `user_id`, `api_key_id`, `source`, and a `since`/`until` range, and bounds the response:

- `object_changes` is rendered as `field -> {from, to}`, long values trimmed, at most 25 fields with the remainder counted
- the full object state is opt-in via `include_full_object`, and stays a mapping rather than being flattened to a string
- at most 25 records, with `total_matching` reported so a wide search can be narrowed

## Two endpoint behaviours are handled, not passed through

Both confirmed against production, and both would otherwise mislead a caller:

**A `404` usually means "no permission", not "not found".** The endpoint deliberately conflates them. Verified by comparing bodies: `/v1/audits` returns a JSON:API error (`"Not found or unauthorized"`) while an unrouted path returns a Rails routing error. Reported as a permission error naming the exact setting — `Audits - read`, under Configuration → Roles & Permissions — so nobody concludes the feature is missing.

**`filter[item_type]` accepts any value and silently matches zero records.** A misspelling is indistinguishable from "nothing changed". An empty result is annotated when the type is unrecognised, and the note allows for a type added after this list was written rather than insisting on a typo.

It also names the child types that are genuinely **not** audited — schedule rotations, escalation levels, shift overrides, workflow tasks — instead of returning an empty list that reads as evidence of no change. That gap was verified two ways: each returns 0 of 343,005 records, and sampling 50 `Schedule` entries showed `object_changes` carrying only the parent's own columns, with no nested rotation data.

A live `Schedule` record makes the consequence concrete: a rotation edit surfaced as `has_gaps: false → true` and nothing else. The change is detectable on the parent as a derived-field flip, but what was actually edited is not recorded.

## Verification

Ran the tool itself against production across eight scenarios: default listing (343,005 records), `item_type` filtering, both note paths, `max_results` clamping, `include_full_object`, a `since`/`until` range, and the permission path using a token without the role.

The one thing that could have forced a rewrite is settled: `object_changes` arrives in PaperTrail's `[before, after]` shape, so the summariser is correct. The documentation's mention of "humanized field names" did not imply a different structure.

Also checked:

- **17 unit tests, mutation-verified** — removing the 404 handling, either note, the clamp, the field cap, the `max_results` slice, source normalisation, value trimming, or the structured-object fix each fails a test. Every mutation anchor was asserted to match exactly once, so none were silent no-ops.
- **Malformed responses** — null body, missing `data`, `data` as a dict, missing `attributes`, `object_changes` as a list or string: all handled, no uncaught exceptions.
- **Real FastMCP path** — callable with defaults, `"500"` coerced to an int, unknown args and wrong types rejected by validation. A 401 correctly surfaces as an authentication error rather than the permission message, so the taxonomy holds.
- **Full gate** — 936 passed, ruff, ruff-format, mypy and pyright clean, bandit 0 issues, 254 tools with 0 missing annotations.

## Known limits, stated in the docstring

Roughly 60 resource types at the object level, retained indefinitely. Sign-in events are kept separately from this log. Rotations, escalation levels and shift overrides are not covered. A full compliance export belongs on the REST endpoint, since this returns a single page.
