### PR TITLE
Tell callers what to do when they hit the offset-pagination cap

### DIFF
--- a/src/rootly_mcp_server/transport.py
+++ b/src/rootly_mcp_server/transport.py
@@ -1072,6 +1072,7 @@ class AuthenticatedHTTPXClient:
         )
         response = self._maybe_annotate_404_response(method, url, response)
         response = self._maybe_annotate_alert_routing_deprecation(method, url, response)
+        response = self._maybe_annotate_offset_pagination_limit(method, url, response)
 
         return response
 
@@ -1152,6 +1153,65 @@ class AuthenticatedHTTPXClient:
             response._content = json.dumps(body).encode()  # noqa: SLF001
         except Exception:  # nosec B110 - Safe fallback; annotation is best-effort
             pass
+        return response
+
+    @staticmethod
+    def _maybe_annotate_offset_pagination_limit(
+        method: str, url: str, response: httpx.Response
+    ) -> httpx.Response:
+        """Translate the 400 offset-pagination cap into a model-actionable hint.
+
+        Rootly rejects offset pagination past 50,000 records. The tools expose
+        `page_number` with no upper bound, so a model walking a large collection
+        page by page reaches the cap and, with nothing telling it what to do
+        differently, retries the same shape. One caller produced 1,271 of these
+        in six days against `list_alerts`.
+
+        The prose in the upstream body already names the remedy, but it arrives
+        as a sentence inside an errors array. A structured field is surfaced
+        instead so the caller can switch without re-reading the prose, matching
+        how the alert-routing deprecation is handled.
+        """
+        if response.status_code != 400:
+            return response
+        try:
+            body = response.json()
+        except Exception:  # nosec B110 - best-effort annotation
+            return response
+        if not isinstance(body, dict):
+            return response
+        errors = body.get("errors")
+        first_title = ""
+        if isinstance(errors, list) and errors and isinstance(errors[0], dict):
+            first_title = str(errors[0].get("title", ""))
+        if "offset pagination is limited" not in first_title.lower():
+            return response
+        body.setdefault(
+            "_use_cursor_pagination",
+            {
+                "instead_of": "page_number",
+                "use": "page_after",
+                "reason": (
+                    "This request is past the offset-pagination cap. page_number "
+                    "cannot reach any further, so retrying it will keep failing."
+                ),
+                "how": (
+                    "Narrowing the query is usually the practical fix: a shorter "
+                    "created_at range, or a status/service filter, brings the "
+                    "result under the cap where page_number keeps working. To "
+                    "walk the whole collection instead, switch to cursors — "
+                    "request the first page without page_number, read "
+                    "meta.next_cursor, pass it as page_after, and repeat with "
+                    "each response's cursor. Filters are preserved across "
+                    "cursor pages. Note that a cursor walk restarts from the "
+                    "beginning; it cannot resume at the page you stopped on."
+                ),
+            },
+        )
+        try:
+            response._content = json.dumps(body).encode()  # noqa: SLF001
+        except Exception:  # nosec B110 - best-effort annotation
+            return response
         return response
 
     @staticmethod
@@ -1435,7 +1495,12 @@ class AuthenticatedHTTPXClient:
         response = self._maybe_normalize_incident_form_field_selection_response(
             request.method, str(request.url), response
         )
+        # Auto-generated tools reach the API through send(), not request(), so
+        # an annotator only applied on request() never reaches them.
         response = self._maybe_annotate_alert_routing_deprecation(
+            request.method, str(request.url), response
+        )
+        response = self._maybe_annotate_offset_pagination_limit(
             request.method, str(request.url), response
         )
         return response

--- a/tests/unit/test_transport_module.py
+++ b/tests/unit/test_transport_module.py
@@ -1,5 +1,6 @@
 """Focused tests for transport module."""
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -1379,3 +1380,183 @@ class TestAuthCaptureMiddlewareWWWAuthenticate:
             header_dict[b"www-authenticate"]
             == b'Bearer resource_metadata="https://mcp.rootly.com/.well-known/oauth-protected-resource"'
         )
+
+
+def _pagination_400(body: dict | list | str | None = None) -> httpx.Response:
+    """A 400 shaped like Rootly's offset-pagination rejection."""
+    if body is None:
+        body = {
+            "errors": [
+                {
+                    "title": (
+                        "Offset pagination is limited to 50000 records. Use "
+                        "cursor-based pagination (page[after]) for deeper results. "
+                        "The first page response includes a next_cursor value in "
+                        "the meta object."
+                    ),
+                    "status": "400",
+                }
+            ]
+        }
+    content = body if isinstance(body, bytes | str) else json.dumps(body)
+    if isinstance(content, str):
+        content = content.encode()
+    return httpx.Response(
+        status_code=400,
+        content=content,
+        request=httpx.Request("GET", "https://api.rootly.com/v1/alerts?page%5Bnumber%5D=5000"),
+    )
+
+
+@pytest.mark.unit
+class TestOffsetPaginationHint:
+    """The offset cap is reachable through page_number, and the cap is terminal.
+
+    One caller produced 1,271 of these against list_alerts in six days, retrying
+    the same shape because nothing in the response told it to switch.
+    """
+
+    def _annotate(self, response: httpx.Response) -> httpx.Response:
+        return transport.AuthenticatedHTTPXClient._maybe_annotate_offset_pagination_limit(
+            "GET", "https://api.rootly.com/v1/alerts", response
+        )
+
+    def test_offset_cap_gets_a_cursor_hint(self):
+        body = self._annotate(_pagination_400()).json()
+
+        hint = body["_use_cursor_pagination"]
+        assert hint["instead_of"] == "page_number"
+        assert hint["use"] == "page_after"
+        # The remedy has to name next_cursor, which is what the caller reads
+        # from the response to make progress.
+        assert "next_cursor" in hint["how"]
+
+    def test_hint_rules_out_retrying_the_same_shape(self):
+        # Retrying page_number produced 1,271 failures: the observed callers sat
+        # at pages 5,003-5,159 and reissued each roughly six times.
+        reason = self._annotate(_pagination_400()).json()["_use_cursor_pagination"]["reason"]
+        assert "page_number" in reason
+        assert "cannot reach any further" in reason or "keep failing" in reason
+
+    def test_hint_offers_narrowing_before_a_cursor_walk(self):
+        # The affected callers were walking a filtered range and crossed the cap
+        # at page 5,001. A cursor walk restarts from the beginning, so re-walking
+        # 50,000 records is worse advice than narrowing the range.
+        how = self._annotate(_pagination_400()).json()["_use_cursor_pagination"]["how"]
+        assert "filter" in how.lower(), "expected narrowing to be offered"
+        assert how.lower().index("narrow") < how.lower().index("cursor"), (
+            "narrowing should be offered before the cursor walk"
+        )
+
+    def test_hint_is_honest_that_a_cursor_walk_restarts(self):
+        # Without this the caller may believe page_after can resume where
+        # page_number stopped, which it cannot.
+        how = self._annotate(_pagination_400()).json()["_use_cursor_pagination"]["how"]
+        assert "restarts from the beginning" in how or "cannot resume" in how
+
+    def test_unrelated_400_is_left_alone(self):
+        other = _pagination_400({"errors": [{"title": "Page size exceeds maximum of 1000"}]})
+        assert "_use_cursor_pagination" not in self._annotate(other).json()
+
+    def test_non_400_is_left_alone(self):
+        ok = httpx.Response(
+            status_code=200,
+            content=json.dumps({"data": []}).encode(),
+            request=httpx.Request("GET", "https://api.rootly.com/v1/alerts"),
+        )
+        assert "_use_cursor_pagination" not in self._annotate(ok).json()
+
+    def test_non_dict_body_does_not_raise(self):
+        assert self._annotate(_pagination_400(["not", "a", "dict"])).status_code == 400
+
+    def test_non_json_body_does_not_raise(self):
+        assert self._annotate(_pagination_400("<html>gateway</html>")).status_code == 400
+
+    def test_existing_hint_is_not_overwritten(self):
+        body = {
+            "errors": [{"title": "Offset pagination is limited to 50000 records."}],
+            "_use_cursor_pagination": {"use": "already-set"},
+        }
+        got = self._annotate(_pagination_400(body)).json()
+        assert got["_use_cursor_pagination"] == {"use": "already-set"}
+
+
+@pytest.mark.unit
+class TestHintSurvivesToolErrorFormatting:
+    """Attaching the hint is worthless if the caller never sees it.
+
+    Auto-generated tools raise on 4xx. FastMCP builds the message from
+    e.response.json(), and e.response is the same object the annotator
+    mutated, so the hint travels inside the ValueError the model receives.
+    This pins that path rather than assuming it.
+    """
+
+    def test_hint_appears_in_the_error_message_the_caller_receives(self):
+        annotated = transport.AuthenticatedHTTPXClient._maybe_annotate_offset_pagination_limit(
+            "GET", "https://api.rootly.com/v1/alerts", _pagination_400()
+        )
+
+        # Mirrors fastmcp/server/providers/openapi/components.py: raise_for_status
+        # then rebuild the message from the response body.
+        try:
+            annotated.raise_for_status()
+            raise AssertionError("expected a 400 to raise")
+        except httpx.HTTPStatusError as exc:
+            message = f"HTTP error {exc.response.status_code}: {exc.response.reason_phrase}"
+            message += f" - {exc.response.json()}"
+
+        assert "_use_cursor_pagination" in message
+        assert "page_after" in message
+
+
+@pytest.mark.unit
+class TestAnnotatorsReachBothTransportPaths:
+    """Annotating in isolation is not enough; it has to be wired into both paths.
+
+    Auto-generated tools reach the API through send(); curated tools go through
+    request(). The 404 plan-gating hint was wired only into request(), so the
+    tools it was written for never received it, and the existing tests did not
+    catch that because they call the annotators directly.
+    """
+
+    def _client(self):
+        with patch.object(
+            transport.AuthenticatedHTTPXClient, "_get_api_token", return_value="token"
+        ):
+            return transport.AuthenticatedHTTPXClient(hosted=False, transport="stdio")
+
+    @pytest.mark.asyncio
+    async def test_request_path_annotates_the_offset_cap(self):
+        client = self._client()
+        client.client.request = AsyncMock(return_value=_pagination_400())
+
+        returned = await client.request("GET", "/v1/alerts")
+
+        assert "_use_cursor_pagination" in returned.json()
+
+    @pytest.mark.asyncio
+    async def test_send_path_annotates_the_offset_cap(self):
+        # send() is the path auto-generated tools use, including list_alerts.
+        client = self._client()
+        client.client.send = AsyncMock(return_value=_pagination_400())
+
+        returned = await client.send(httpx.Request("GET", "https://api.rootly.com/v1/alerts"))
+
+        assert "_use_cursor_pagination" in returned.json()
+
+    def test_response_strippers_leave_error_bodies_for_the_annotators(self):
+        # The strippers run before the annotators and rewrite _content. If one
+        # ever stopped skipping error responses it would replace the errors
+        # array the annotators match on, silently disabling every hint.
+        body = json.dumps({"errors": [{"title": "Offset pagination is limited to 50000 records."}]})
+        for stripper in (
+            transport.AuthenticatedHTTPXClient._maybe_strip_alert_response,
+            transport.AuthenticatedHTTPXClient._maybe_strip_collection_response,
+        ):
+            response = httpx.Response(
+                status_code=400,
+                content=body.encode(),
+                request=httpx.Request("GET", "https://api.rootly.com/v1/alerts"),
+            )
+            out = stripper("GET", "https://api.rootly.com/v1/alerts", response)
+            assert out.json() == json.loads(body), f"{stripper.__name__} altered an error body"


### PR DESCRIPTION
`list_alerts` was the largest error cluster in the service: **1,340 errors in 30 days, 1,271 of them one rejection.**

```
HTTP 400: Offset pagination is limited to 50000 records.
```

## Should this be a limit instead?

That was the first question, and the traces answer it. Extracting the real request URLs:

| Requested page | `page_size` | Offset | Count |
|---|---|---|---|
| 5,003 – 5,159 | 10 | 50,030 – 51,590 | **1,270** |
| 153,975 | 2 | 307,950 | 1 |

The failing requests are **not runaway loops**. Page numbers cluster tightly just past the boundary, each reissued about six times — callers walking a filtered range sequentially, crossing the cap at page 5,001, and grinding on for another 160 pages. Exactly one request in 1,271 was pathological.

That rules out capping `page_number`:

- **Clamping** would pin a mid-walk caller at page 5,000 and return the same rows forever. The walk would never terminate *and* would silently yield duplicates — a loud error replaced by quiet wrong data.
- **A hard maximum** would reject them with no way forward, and couldn't be expressed correctly anyway: the cap depends on `page_size`, so no static bound is right for both `page_size=2` and `page_size=20`.

The cap has to stay an error. What was missing is what to do next.

## The change

The upstream body already names cursors, but as prose inside an `errors` array. This surfaces a structured field, matching how the `/alert_routing_rules` 403 is handled:

```json
"_use_cursor_pagination": {
  "instead_of": "page_number",
  "use": "page_after",
  "reason": "This request is past the offset-pagination cap. page_number cannot reach any further...",
  "how": "Narrowing the query is usually the practical fix... To walk the whole collection instead, switch to cursors... Note that a cursor walk restarts from the beginning; it cannot resume at the page you stopped on."
}
```

**The advice leads with narrowing rather than cursors, deliberately.** A cursor walk restarts from the beginning, so telling someone 50,000 records deep to switch to cursors means re-walking everything they already have. The hint says that explicitly instead of implying cursors can resume.

## Verified against production, not fixtures

- Reproducing the exact failing shape (`page[size]=10&page[number]=5179`) returns the real 400; feeding **that body** through the annotator produces the hint and preserves the original `errors` array.
- **The hint reaches the caller.** Auto-generated tools raise on 4xx, and FastMCP rebuilds the message from `e.response.json()` — the same object the annotator mutated — so the hint travels inside the `ValueError` the model receives. Pinned by a test rather than assumed.
- **Cursors work with the filters these callers use.** They pass `created_at` ranges; cursor pages preserve filters and return a further cursor. Checked live, because advice that doesn't work for the affected population is worse than none.

## Tests

13 tests across four levels: the hint's content, its delivery through `ValueError`, its arrival via both `request()` and `send()`, and an invariant that the response strippers keep skipping error bodies — they rewrite `_content` before the annotators run, so if one stopped guarding on `is_success` it would replace the `errors` array every hint matches on.

Assertions check content rather than phrasing, after an earlier version broke on a wording change.

Mutation-checked: neutralising the annotation fails 5 tests; removing it from `send()` fails the wiring tests.

Full gate: 949 passed, ruff, ruff-format, mypy, pyright clean.

## Not included

`page_number` still has no maximum — deliberately, per the analysis above. Making `page_after` discoverable *before* the wall would mean overriding the generated parameter description in `spec_transform`, which is a larger change and belongs on its own.
